### PR TITLE
Decode emoji when using HTML entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-native-community/netinfo": "^9.0.0",
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-native-cookies/cookies": "^6.0.11",
+    "@xmldom/xmldom": "xmldom/xmldom",
     "axios": "^0.22.0",
     "markdown-it": "^13.0.1",
     "mobx": "^6.3.3",

--- a/src/stores/models/posting/Post.js
+++ b/src/stores/models/posting/Post.js
@@ -1,6 +1,8 @@
 import { types } from 'mobx-state-tree';
 import { DOMParser } from "@xmldom/xmldom";
 
+let html_parser = new DOMParser();
+
 export default Post = types.model('Post', {
   uid: types.identifierNumber,
   name: types.maybe(types.string),
@@ -15,8 +17,7 @@ export default Post = types.model('Post', {
   
   plain_text_content(){
     let html = "<p>" + self.content + "</p>";
-    let parser = new DOMParser();    
-    let doc = parser.parseFromString(html, "text/html");
+    let doc = html_parser.parseFromString(html, "text/html");
     let text = doc.documentElement.textContent;
 
     if (text.length > 300) {

--- a/src/stores/models/posting/Post.js
+++ b/src/stores/models/posting/Post.js
@@ -1,4 +1,5 @@
 import { types } from 'mobx-state-tree';
+import { DOMParser } from "@xmldom/xmldom";
 
 export default Post = types.model('Post', {
   uid: types.identifierNumber,
@@ -13,8 +14,11 @@ export default Post = types.model('Post', {
 .views(self => ({
   
   plain_text_content(){
-    const regex = /(<[^>]+>)/ig
-    let plain_text = self.content.replace(regex, '')
+    let html = "<p>" + self.content + "</p>";
+    let parser = new DOMParser();    
+    let doc = parser.parseFromString(html, "text/html");
+    let plain_text = doc.documentElement.textContent;
+
     if (plain_text.length > 300) {
       plain_text = plain_text.substring(0, 300) + '...'
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,6 +1959,10 @@
     "@typescript-eslint/types" "5.50.0"
     eslint-visitor-keys "^3.3.0"
 
+"@xmldom/xmldom@xmldom/xmldom":
+  version "0.9.0-beta.6"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/d7e91459467b97ccdccac54e515b6247d9da058c"
+
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"


### PR DESCRIPTION
@vincentritter Here's a pull request with my experiment in decoding HTML entities using DOMParser. I forgot I'm actually using something similar to this in Epilogue. It's another dependency but it's really useful for doing stuff with HTML.

It works well for the emoji. I did notice a console warning with some unknown HTML tags, but haven't debugged that yet.