### PR TITLE
Username auto-complete

### DIFF
--- a/src/api/MicroBlogApi.js
+++ b/src/api/MicroBlogApi.js
@@ -331,6 +331,25 @@ class MicroBlogApi {
 			});
 		return posts;
 	}
+
+	async find_users(username) {
+		console.log('MicroBlogApi: find_users', username);
+		const push = axios
+			.get(`/micropub?q=contact&filter=${username}`, {
+				headers: { Authorization: `Bearer ${Auth.selected_user?.token()}` },
+			})
+			.then(response => {
+				if(response.data != null){
+					return response.data
+				}
+				return API_ERROR;
+			})
+			.catch(error => {
+				console.log('MicroBlogApi: find_users', error);
+				return API_ERROR;
+			});
+		return push;
+	}
   
 }
 

--- a/src/components/keyboard/post_toolbar.js
+++ b/src/components/keyboard/post_toolbar.js
@@ -104,7 +104,7 @@ export default class PostToolbar extends React.Component{
 								padding: 2,
 								color: App.theme_text_color(),
 								position: 'absolute',
-								top: !this.props.is_post_edit ? -35 : -55,
+								top: posting.post_chars_offset(this.props.is_post_edit),
 								right: 0
 							}}
 						><Text style={{ color: posting.post_text_length() > posting.max_post_length() ? '#a94442' : App.theme_text_color() }}>{posting.post_text_length()}</Text>/{posting.max_post_length()}</Text>

--- a/src/components/keyboard/post_toolbar.js
+++ b/src/components/keyboard/post_toolbar.js
@@ -33,18 +33,9 @@ export default class PostToolbar extends React.Component{
 				}}
 			>
 				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
-					<TouchableOpacity style={{minWidth: 35}} onPress={() => posting.handle_text_action("**")}>
-						<Text style={{ fontSize: 18, fontWeight: '600', textAlign: 'center', padding: 2, color: App.theme_text_color() }}>{"**"}</Text>
-					</TouchableOpacity>
-					<TouchableOpacity style={{minWidth: 35}} onPress={() => posting.handle_text_action("_")}>
-						<Text style={{ fontSize: 18, fontWeight: '600', textAlign: 'center', padding: 2, color: App.theme_text_color() }}>{"_"}</Text>
-					</TouchableOpacity>
-					<TouchableOpacity style={{minWidth: 35}} onPress={() => posting.handle_text_action("[]")}>
-						<Text style={{ fontSize: 18, fontWeight: '600', textAlign: 'center', padding: 2, color: App.theme_text_color() }}>{"[ ]"}</Text>
-					</TouchableOpacity>
 					{
 						!this.props.is_post_edit &&
-						<TouchableOpacity style={{minWidth: 35, marginLeft: 8, marginRight: 8}} onPress={posting.handle_asset_action}>
+						<TouchableOpacity style={{minWidth: 35, marginLeft: 4, marginRight: 0}} onPress={posting.handle_asset_action}>
 						{
 							Platform.OS === 'ios' ?
 								<SFSymbol
@@ -58,9 +49,18 @@ export default class PostToolbar extends React.Component{
 						}
 						</TouchableOpacity>
 					}
+					<TouchableOpacity style={{minWidth: 35}} onPress={() => posting.handle_text_action("**")}>
+						<Text style={{ fontSize: 18, fontWeight: '600', textAlign: 'center', padding: 2, color: App.theme_text_color() }}>{"**"}</Text>
+					</TouchableOpacity>
+					<TouchableOpacity style={{minWidth: 35}} onPress={() => posting.handle_text_action("_")}>
+						<Text style={{ fontSize: 18, fontWeight: '600', textAlign: 'center', padding: 2, color: App.theme_text_color() }}>{"_"}</Text>
+					</TouchableOpacity>
+					<TouchableOpacity style={{minWidth: 35}} onPress={() => posting.handle_text_action("[]")}>
+						<Text style={{ fontSize: 18, fontWeight: '600', textAlign: 'center', padding: 2, color: App.theme_text_color() }}>{"[ ]"}</Text>
+					</TouchableOpacity>
 					{
 						!this.props.is_post_edit && posting.selected_service?.config?.active_destination() != null && posting.selected_service?.config?.destination?.length > 1 ?
-						<TouchableOpacity style={{marginRight: 8}} onPress={() => postingOptionsScreen(this.props.componentId)}>
+						<TouchableOpacity style={{marginLeft: 8, marginRight: 8}} onPress={() => postingOptionsScreen(this.props.componentId)}>
 							<Text style={{ fontSize: 16, fontWeight: '500', textAlign: 'center', color: App.theme_text_color() }}>
 								{posting.selected_service.config.active_destination().name}
 							</Text>

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -37,6 +37,7 @@ export default class UsernameToolbar extends React.Component{
 						{ posting.found_users.map((u, index) => {
 							return (
 								<TouchableOpacity style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
+									posting.update_autocomplete(u.username)
 									console.log("username tapped", u.username);
 								}}>
 									<Image source={{ uri: u.avatar }} style={{ width: 24, height: 24, borderRadius: 12, marginRight: 3 }} />		

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -9,7 +9,6 @@ import { SFSymbol } from 'react-native-sfsymbols';
 export default class UsernameToolbar extends React.Component{
   
 	render() {
-		const { posting } = Auth.selected_user
 		if (App.found_users.length == 0) {
 			return null
 		}
@@ -37,7 +36,7 @@ export default class UsernameToolbar extends React.Component{
 						{ App.found_users.map((u, index) => {
 							return (
 								<TouchableOpacity key={index} style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
-									App.update_autocomplete(u.username, posting)
+									App.update_autocomplete(u.username, this.props.object)
 								}}>
 									<Image source={{ uri: u.avatar }} style={{ width: 24, height: 24, borderRadius: 12, marginRight: 3 }} />		
 									<Text style={{ fontSize: 15, textAlign: 'center', color: App.theme_text_color() }}>

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -2,9 +2,6 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { View, Text, TouchableOpacity, Image, Platform, ScrollView } from 'react-native';
 import Auth from '../../stores/Auth';
-import PhotoLibrary from '../../assets/icons/toolbar/photo_library.png';
-import SettingsIcon from '../../assets/icons/toolbar/settings.png';
-import { postingOptionsScreen } from '../../screens';
 import App from '../../stores/App';
 import { SFSymbol } from 'react-native-sfsymbols';
 
@@ -13,41 +10,46 @@ export default class UsernameToolbar extends React.Component{
   
 	render() {
 		const { posting } = Auth.selected_user
-		return(
-			<View
-				style={{
-					width: '100%',
-					backgroundColor: App.theme_section_background_color(),
-					...Platform.select({
-						android: {
-							position: 'absolute',
-							bottom: 0,
-							right: 0,
-							left: 0,
-						}
-					}),
-					padding: 5,
-					minHeight: 40,
-					flexDirection: 'row',
-					alignItems: 'center'
-				}}
-			>
-				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
-					{ posting.found_users.map((u, index) => {
-						return (
-							<TouchableOpacity style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
-								console.log("username tapped", u.username);
-							}}>
-								<Image source={{ uri: u.avatar }} style={{ width: 24, height: 24, borderRadius: 12, marginRight: 3 }} />		
-								<Text style={{ fontSize: 15, textAlign: 'center', color: App.theme_text_color() }}>
-									@{ u.username }
-								</Text>
-							</TouchableOpacity>
-						)
-					}) }
-				</ScrollView>
-			</View>
-		)
+		if (posting.found_users.length == 0) {
+			return null
+		}
+		else {
+			return(
+				<View
+					style={{
+						width: '100%',
+						backgroundColor: App.theme_section_background_color(),
+						...Platform.select({
+							android: {
+								position: 'absolute',
+								bottom: 0,
+								right: 0,
+								left: 0,
+							}
+						}),
+						padding: 5,
+						minHeight: 40,
+						flexDirection: 'row',
+						alignItems: 'center'
+					}}
+				>
+					<ScrollView keyboardShouldPersistTaps={'always'} horizontal={true} showsHorizontalScrollIndicator={false} style={{overflow: 'hidden'}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
+						{ posting.found_users.map((u, index) => {
+							return (
+								<TouchableOpacity style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
+									console.log("username tapped", u.username);
+								}}>
+									<Image source={{ uri: u.avatar }} style={{ width: 24, height: 24, borderRadius: 12, marginRight: 3 }} />		
+									<Text style={{ fontSize: 15, textAlign: 'center', color: App.theme_text_color() }}>
+										@{ u.username }
+									</Text>
+								</TouchableOpacity>
+							)
+						}) }
+					</ScrollView>
+				</View>
+			)
+		}
 	}
 	  
 }

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -33,13 +33,14 @@ export default class UsernameToolbar extends React.Component{
 				}}
 			>
 				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
-					{ posting.found_usernames.map((username, index) => {
+					{ posting.found_users.map((u, index) => {
 						return (
-							<TouchableOpacity style={{marginLeft: 4, marginRight: 8}} onPress={() => {
-								console.log("username tapped", username);
+							<TouchableOpacity style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
+								console.log("username tapped", u.username);
 							}}>
-								<Text style={{ fontSize: 16, textAlign: 'center', color: App.theme_text_color() }}>
-									@{ username }
+								<Image source={{ uri: u.avatar }} style={{ width: 24, height: 24, borderRadius: 12, marginRight: 3 }} />		
+								<Text style={{ fontSize: 15, textAlign: 'center', color: App.theme_text_color() }}>
+									@{ u.username }
 								</Text>
 							</TouchableOpacity>
 						)

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { View, Text, TouchableOpacity, Image, Platform, ScrollView } from 'react-native';
+import Auth from '../../stores/Auth';
+import PhotoLibrary from '../../assets/icons/toolbar/photo_library.png';
+import SettingsIcon from '../../assets/icons/toolbar/settings.png';
+import { postingOptionsScreen } from '../../screens';
+import App from '../../stores/App';
+import { SFSymbol } from 'react-native-sfsymbols';
+
+@observer
+export default class UsernameToolbar extends React.Component{
+  
+	render() {
+		const { posting } = Auth.selected_user
+		return(
+			<View
+				style={{
+					width: '100%',
+					backgroundColor: App.theme_section_background_color(),
+					...Platform.select({
+						android: {
+							position: 'absolute',
+							bottom: 0,
+							right: 0,
+							left: 0,
+						}
+					}),
+					padding: 5,
+					minHeight: 40,
+					flexDirection: 'row',
+					alignItems: 'center'
+				}}
+			>
+				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
+				</ScrollView>
+			</View>
+		)
+	}
+	  
+}

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -18,7 +18,7 @@ export default class UsernameToolbar extends React.Component{
 				<View
 					style={{
 						width: '100%',
-						backgroundColor: App.theme_section_background_color(),
+						backgroundColor: App.theme_autocomplete_background_color(),
 						...Platform.select({
 							android: {
 								position: 'absolute',

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -36,7 +36,7 @@ export default class UsernameToolbar extends React.Component{
 					<ScrollView keyboardShouldPersistTaps={'always'} horizontal={true} showsHorizontalScrollIndicator={false} style={{overflow: 'hidden'}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
 						{ posting.found_users.map((u, index) => {
 							return (
-								<TouchableOpacity style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
+								<TouchableOpacity key={index} style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
 									posting.update_autocomplete(u.username)
 									console.log("username tapped", u.username);
 								}}>

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -33,6 +33,17 @@ export default class UsernameToolbar extends React.Component{
 				}}
 			>
 				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
+					{ posting.found_usernames.map((username, index) => {
+						return (
+							<TouchableOpacity style={{marginLeft: 4, marginRight: 8}} onPress={() => {
+								console.log("username tapped", username);
+							}}>
+								<Text style={{ fontSize: 16, textAlign: 'center', color: App.theme_text_color() }}>
+									@{ username }
+								</Text>
+							</TouchableOpacity>
+						)
+					}) }
 				</ScrollView>
 			</View>
 		)

--- a/src/components/keyboard/username_toolbar.js
+++ b/src/components/keyboard/username_toolbar.js
@@ -10,7 +10,7 @@ export default class UsernameToolbar extends React.Component{
   
 	render() {
 		const { posting } = Auth.selected_user
-		if (posting.found_users.length == 0) {
+		if (App.found_users.length == 0) {
 			return null
 		}
 		else {
@@ -34,11 +34,10 @@ export default class UsernameToolbar extends React.Component{
 					}}
 				>
 					<ScrollView keyboardShouldPersistTaps={'always'} horizontal={true} showsHorizontalScrollIndicator={false} style={{overflow: 'hidden'}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
-						{ posting.found_users.map((u, index) => {
+						{ App.found_users.map((u, index) => {
 							return (
 								<TouchableOpacity key={index} style={{marginLeft: 4, marginRight: 8, flexDirection: "row"}} onPress={() => {
-									posting.update_autocomplete(u.username)
-									console.log("username tapped", u.username);
+									App.update_autocomplete(u.username, posting)
 								}}>
 									<Image source={{ uri: u.avatar }} style={{ width: 24, height: 24, borderRadius: 12, marginRight: 3 }} />		
 									<Text style={{ fontSize: 15, textAlign: 'center', color: App.theme_text_color() }}>

--- a/src/screens/conversation/reply.js
+++ b/src/screens/conversation/reply.js
@@ -4,6 +4,7 @@ import { View, TextInput, Keyboard, ActivityIndicator, InputAccessoryView, Platf
 import { Navigation } from 'react-native-navigation';
 import Reply from '../../stores/Reply'
 import ReplyToolbar from '../../components/keyboard/reply_toolbar'
+import UsernameToolbar from '../../components/keyboard/username_toolbar'
 import App from '../../stores/App'
 
 @observer
@@ -59,7 +60,7 @@ export default class ReplyScreen extends React.Component{
 					enablesReturnKeyAutomatically={true}
 					underlineColorAndroid={'transparent'}
           value={Reply.reply_text}
-          onChangeText={(text) => !Reply.is_sending_reply ? Reply.set_reply_text(text) : null}
+          onChangeText={(text) => !Reply.is_sending_reply ? Reply.set_reply_text_from_typing(text) : null}
           onSelectionChange={({ nativeEvent: { selection } }) => {
             Reply.set_text_selection(selection)
           }}
@@ -68,9 +69,14 @@ export default class ReplyScreen extends React.Component{
         {
           Platform.OS === 'ios' ?
             <InputAccessoryView nativeID={this.input_accessory_view_id}>
+              <UsernameToolbar componentId={this.props.componentId} object={Reply} />
               <ReplyToolbar reply={Reply} />
             </InputAccessoryView>
-          :  <ReplyToolbar reply={Reply} />
+          :  
+          <>
+            <UsernameToolbar componentId={this.props.componentId} object={Reply} />
+            <ReplyToolbar reply={Reply} />
+          </>
         }
         {
           Reply.is_sending_reply ?

--- a/src/screens/posts/new.js
+++ b/src/screens/posts/new.js
@@ -131,13 +131,13 @@ export default class PostingScreen extends React.Component{
         {
           Platform.OS === 'ios' ?
             <InputAccessoryView nativeID={this.input_accessory_view_id}>
-              <UsernameToolbar componentId={this.props.componentId} />
+              <UsernameToolbar componentId={this.props.componentId} object={posting} />
               <AssetToolbar componentId={this.props.componentId} />
               <PostToolbar componentId={this.props.componentId} />
             </InputAccessoryView>
           :  
           <>
-            <UsernameToolbar componentId={this.props.componentId} />
+            <UsernameToolbar componentId={this.props.componentId} object={posting} />
             <AssetToolbar componentId={this.props.componentId} />
             <PostToolbar componentId={this.props.componentId} />
           </>

--- a/src/screens/posts/new.js
+++ b/src/screens/posts/new.js
@@ -3,9 +3,10 @@ import { observer } from 'mobx-react';
 import { View, TextInput, Keyboard, ActivityIndicator, InputAccessoryView, Platform, KeyboardAvoidingView } from 'react-native';
 import { Navigation } from 'react-native-navigation';
 import Auth from '../../stores/Auth';
-import PostToolbar from '../../components/keyboard/post_toolbar'
-import App from '../../stores/App'
+import App from '../../stores/App';
+import PostToolbar from '../../components/keyboard/post_toolbar';
 import AssetToolbar from '../../components/keyboard/asset_toolbar';
+import UsernameToolbar from '../../components/keyboard/username_toolbar';
 
 @observer
 export default class PostingScreen extends React.Component{
@@ -130,11 +131,13 @@ export default class PostingScreen extends React.Component{
         {
           Platform.OS === 'ios' ?
             <InputAccessoryView nativeID={this.input_accessory_view_id}>
+              <UsernameToolbar componentId={this.props.componentId} />
               <AssetToolbar componentId={this.props.componentId} />
               <PostToolbar componentId={this.props.componentId} />
             </InputAccessoryView>
           :  
           <>
+            <UsernameToolbar componentId={this.props.componentId} />
             <AssetToolbar componentId={this.props.componentId} />
             <PostToolbar componentId={this.props.componentId} />
           </>

--- a/src/screens/posts/new.js
+++ b/src/screens/posts/new.js
@@ -120,7 +120,7 @@ export default class PostingScreen extends React.Component{
               enablesReturnKeyAutomatically={true}
               underlineColorAndroid={'transparent'}
               value={posting.post_text}
-              onChangeText={(text) => !posting.is_sending_post ? posting.set_post_text(text) : null}
+              onChangeText={(text) => !posting.is_sending_post ? posting.set_post_text_from_typing(text) : null}
               onSelectionChange={({ nativeEvent: { selection } }) => {
                 posting.set_text_selection(selection)
               }}

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -567,6 +567,9 @@ export default App = types.model('App', {
   theme_settings_group_background_color() {
     return self.theme === "dark" ? "#1F2937" : "#eff1f3"
   },
+  theme_autocomplete_background_color() {
+    return self.theme === "dark" ? "#1c2028" : "#f4f6f8"
+  },
   should_reload_web_view() {
     // When it returns true, this will trigger a reload of the webviews
     return self.is_switching_theme || self.is_changing_font_scale

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -520,6 +520,7 @@ export default App = types.model('App', {
     
     // for a quick test, we're just going to grab usernames regardless of insertion point
     // later, will be smarter about only checking the username that is being typed
+    // TODO: use Posting.text_selection
     
     const regex = /\@([a-z][A-Z]*)/ig
     const pieces = s.match(regex)

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -556,8 +556,16 @@ export default App = types.model('App', {
   
   update_autocomplete: flow(function* (selected_username, obj) {
     var s = obj.post_text
-    s = s.replace("@" + self.current_autocomplete, "@" + selected_username + " ")
-    obj.set_post_text(s)
+    if (s == undefined) {
+      s = obj.reply_text
+    }
+    s = s.replace("@" + App.current_autocomplete, "@" + selected_username + " ")
+    if (obj.reply_text != undefined) {
+      obj.set_reply_text(s)
+    }
+    else {
+      obj.set_post_text(s)
+    }
     App.found_users = []
     App.current_autocomplete = ""
   })

--- a/src/stores/Reply.js
+++ b/src/stores/Reply.js
@@ -46,6 +46,11 @@ export default Reply = types.model('Reply', {
   set_reply_text: flow(function* (value) {
 		self.reply_text = value
   }),
+
+  set_reply_text_from_typing: flow(function* (value) {
+    self.reply_text = value
+    App.check_usernames(self.reply_text)
+  }),
   
   send_reply: flow(function* () {
 		console.log("Reply:send_reply", self.reply_text)

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -336,6 +336,9 @@ export default Posting = types.model('Posting', {
         }
       }
     }
+    else {
+      self.found_users = []
+    }
   })
 }))
 .views(self => ({

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -321,7 +321,7 @@ export default Posting = types.model('Posting', {
     const regex = /\@([a-z][A-Z]*)/ig
     const pieces = s.match(regex)
     if (pieces != null) {
-      const username = pieces[0].substr(1) // get rid of @
+      const username = pieces[pieces.length - 1].substr(1) // get rid of @
       if (username.length >= 3) {
         // make sure this is at the end of the text for now
         const len = s.length

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -383,6 +383,23 @@ export default Posting = types.model('Posting', {
     const html = parser.render(self.post_text)
     const has_blockquote = html.includes('<blockquote')
     return has_blockquote ? App.max_characters_allowed * 2 : App.max_characters_allowed
+  },
+  
+  post_chars_offset(is_post_edit) {
+    var offset = 0
+    if (is_post_edit) {
+      offset = -55
+    }
+    else {
+      offset = -35
+    }
+    
+   if (self.found_users.length > 0) {
+     // if usernames bar, move chars counter higher
+     offset -= 40
+   }
+    
+    return offset
   }
   
 }))

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -353,7 +353,7 @@ export default Posting = types.model('Posting', {
   
   update_autocomplete: flow(function* (selected_username) {
     var s = self.post_text;
-    s = s.replace("@" + self.current_autocomplete, "@" + selected_username)
+    s = s.replace("@" + self.current_autocomplete, "@" + selected_username + " ")
     self.post_text = s
     self.found_users = []
     self.current_autocomplete = ""

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -6,6 +6,7 @@ import MicroPubApi, { POST_ERROR } from '../../api/MicroPubApi';
 import MicroBlogApi, { API_ERROR } from '../../api/MicroBlogApi';
 import { launchImageLibrary } from 'react-native-image-picker';
 import MediaAsset from './posting/MediaAsset'
+import Contact from './posting/Contact'
 import App from '../App'
 import Clipboard from '@react-native-clipboard/clipboard';
 import { imageOptionsScreen, POSTING_SCREEN } from '../../screens';
@@ -32,7 +33,7 @@ export default Posting = types.model('Posting', {
   ),
   is_editing_post: types.optional(types.boolean, false),
   post_url: types.maybeNull(types.string),
-  found_usernames: types.optional(types.array(types.string), []),
+  found_users: types.optional(types.array(Contact), []),
 })
 .actions(self => ({
 
@@ -324,9 +325,13 @@ export default Posting = types.model('Posting', {
       if (username.length >= 3) {
         const results = yield MicroBlogApi.find_users(username)
         if (results !== API_ERROR && results.contacts != null) {
-          self.found_usernames = []
+          self.found_users = []
           for (var c of results.contacts) {
-            self.found_usernames.push(c.nickname)
+            const u = Contact.create({
+              username: c.nickname,
+              avatar: c.photo
+            })
+            self.found_users.push(u)
           }
         }
       }

--- a/src/stores/models/posting/Contact.js
+++ b/src/stores/models/posting/Contact.js
@@ -1,0 +1,8 @@
+import { types, flow } from 'mobx-state-tree';
+
+export default Contact = types.model('Contact', {
+	username: types.maybe(types.string),
+	avatar: types.maybe(types.string)
+})
+.actions(self => ({
+}))


### PR DESCRIPTION
I'm going to call this "done" for now and ship a beta, but there are a few things that can be revisited before 3.0 ships, or shortly after:

* Only works if the username is at the end of the text. This is the common case, of course. If someone repositions the cursor to edit a different username, we should be using the saved `text_selection` and just work backwards to the `@`-sign.
* Can send multiple queries to server at once if you type too fast. Ideally would throttle and only hit the server after 0.5 seconds have passed. I experimented with setTimeout/clearTimeout to fix this, but it created other problems.
* Results from multiple server queries can come back in different orders, potentially breaking the simple `replace()` on the username. Using the `text_selection` for smarter replacement will fix this.