### PR TITLE
Square photos

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -461,6 +461,8 @@ PODS:
     - React-Core
     - SDWebImage (~> 5.11.1)
     - SDWebImageWebPCoder (~> 0.8.4)
+  - RNFS (2.20.0):
+    - React-Core
   - RNGestureHandler (2.9.0):
     - React-Core
   - RNInAppBrowser (3.7.0):
@@ -578,6 +580,7 @@ DEPENDENCIES:
   - "RNCPushNotificationIOS (from `../node_modules/@react-native-community/push-notification-ios`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNFastImage (from `../node_modules/react-native-fast-image`)
+  - RNFS (from `../node_modules/react-native-fs`)
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNInAppBrowser (from `../node_modules/react-native-inappbrowser-reborn`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
@@ -700,6 +703,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-device-info"
   RNFastImage:
     :path: "../node_modules/react-native-fast-image"
+  RNFS:
+    :path: "../node_modules/react-native-fs"
   RNGestureHandler:
     :path: "../node_modules/react-native-gesture-handler"
   RNInAppBrowser:
@@ -773,6 +778,7 @@ SPEC CHECKSUMS:
   RNCPushNotificationIOS: 87b8d16d3ede4532745e05b03c42cff33a36cc45
   RNDeviceInfo: aad3c663b25752a52bf8fce93f2354001dd185aa
   RNFastImage: 5c9c9fed9c076e521b3f509fe79e790418a544e8
+  RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 071d7a9ad81e8b83fe7663b303d132406a7d8f39
   RNInAppBrowser: e36d6935517101ccba0e875bac8ad7b0cb655364
   RNReanimated: cc5e3aa479cb9170bcccf8204291a6950a3be128

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -341,6 +341,9 @@ PODS:
     - glog
   - react-native-cookies (6.2.1):
     - React-Core
+  - react-native-image-editor (2.3.0):
+    - React
+    - React-RCTImage
   - react-native-image-picker (4.10.3):
     - React-Core
   - react-native-netinfo (9.3.7):
@@ -555,6 +558,7 @@ DEPENDENCIES:
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - "react-native-cookies (from `../node_modules/@react-native-cookies/cookies`)"
+  - "react-native-image-editor (from `../node_modules/@react-native-community/image-editor`)"
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-sensitive-info (from `../node_modules/react-native-sensitive-info`)
@@ -653,6 +657,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/logger"
   react-native-cookies:
     :path: "../node_modules/@react-native-cookies/cookies"
+  react-native-image-editor:
+    :path: "../node_modules/@react-native-community/image-editor"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
   react-native-netinfo:
@@ -753,6 +759,7 @@ SPEC CHECKSUMS:
   React-jsinspector: ea8101acf525ec08b2d87ddf0637d45f8e3b4148
   React-logger: 97987f46779d8dd24656474ad0c43a5b459f31d6
   react-native-cookies: f54fcded06bb0cda05c11d86788020b43528a26c
+  react-native-image-editor: 9361a215c3991cafbe5e7f28cbbad6e72c9c2705
   react-native-image-picker: 60f4246eb5bb7187fc15638a8c1f13abd3820695
   react-native-netinfo: 2517ad504b3d303e90d7a431b0fcaef76d207983
   react-native-sensitive-info: 400c6e3d27945e15c8cddb5b4b92233c85ee06f8

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-native-actions-sheet": "^0.8.10",
     "react-native-device-info": "^8.4.9",
     "react-native-fast-image": "^8.5.11",
+    "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.9.0",
     "react-native-hyperlink": "^0.0.22",
     "react-native-image-picker": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-proposal-decorators": "^7.15.8",
     "@react-native-async-storage/async-storage": "^1.17.11",
     "@react-native-clipboard/clipboard": "^1.10.0",
+    "@react-native-community/image-editor": "^2.3.0",
     "@react-native-community/netinfo": "^9.0.0",
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-native-cookies/cookies": "^6.0.11",

--- a/src/components/keyboard/post_toolbar.js
+++ b/src/components/keyboard/post_toolbar.js
@@ -35,7 +35,7 @@ export default class PostToolbar extends React.Component{
 				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
 					{
 						!this.props.is_post_edit &&
-						<TouchableOpacity style={{minWidth: 35, marginLeft: 4, marginRight: 0}} onPress={() => posting.handle_crop_action(this.props.componentId)}>
+						<TouchableOpacity style={{minWidth: 35, marginLeft: 4, marginRight: 0}} onPress={() => posting.handle_asset_action(this.props.componentId)}>
 						{
 							Platform.OS === 'ios' ?
 								<SFSymbol

--- a/src/components/keyboard/post_toolbar.js
+++ b/src/components/keyboard/post_toolbar.js
@@ -35,7 +35,7 @@ export default class PostToolbar extends React.Component{
 				<ScrollView keyboardShouldPersistTaps={'always'}  horizontal={true} style={{overflow: 'hidden', maxWidth: "90%"}} contentContainerStyle={{flexDirection: 'row', alignItems: 'center'}}>
 					{
 						!this.props.is_post_edit &&
-						<TouchableOpacity style={{minWidth: 35, marginLeft: 4, marginRight: 0}} onPress={posting.handle_asset_action}>
+						<TouchableOpacity style={{minWidth: 35, marginLeft: 4, marginRight: 0}} onPress={() => posting.handle_crop_action(this.props.componentId)}>
 						{
 							Platform.OS === 'ios' ?
 								<SFSymbol

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -778,17 +778,17 @@ export const imageOptionsScreen = (image, index, component_id) => {
   return Navigation.push(component_id, options);
 }
 
-export const imageCropScreen = (asset, component_id) => {
+export const imageCropScreen = async (asset, component_id) => {
   console.log("Screens:imageCropScreen");
   
-  asset.save_to_temp()
+  const new_asset = await asset.save_to_temp()
   
   const options = {
     component: {
       id: IMAGE_CROP_SCREEN,
       name: IMAGE_CROP_SCREEN,
       passProps: {
-        asset: asset
+        asset: new_asset
       },
       options: {
         topBar: {
@@ -797,7 +797,7 @@ export const imageCropScreen = (asset, component_id) => {
           },
           rightButtons: [
             {
-              id: 'add_photo_button',
+              id: 'add_image_button',
               text: 'Add Photo',
               color: App.theme_accent_color()
             }

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -22,6 +22,7 @@ import BookmarkScreen from "./bookmarks/bookmark";
 import AddBookmarkScreen from "./bookmarks/add_bookmark";
 import HelpScreen from "./help/help";
 import ImageOptionsScreen from "./posts/image_options";
+import ImageCropScreen from "./posts/image_crop";
 import RepliesScreen from "./replies/replies";
 import ReplyEditScreen from "./replies/edit";
 import SettingsScreen from "./settings/settings";
@@ -45,6 +46,7 @@ export const BOOKMARK_SCREEN = 'microblog.BookmarkScreen';
 export const ADD_BOOKMARK_SCREEN = 'microblog.modal.AddBookmarkScreen';
 export const HELP_SCREEN = 'microblog.modal.HelpScreen';
 export const IMAGE_OPTIONS_SCREEN = 'microblog.modal.ImageOptionsScreen';
+export const IMAGE_CROP_SCREEN = 'microblog.modal.ImageCropScreen';
 export const REPLIES_SCREEN = 'micrblog.RepliesScreen';
 export const REPLY_EDIT_SCREEN = 'microblog.ReplyEditScreen';
 export const SETTINGS_SCREEN = 'microblog.modal.SettingsScreen';
@@ -105,6 +107,7 @@ Screens.set(BOOKMARK_SCREEN, BookmarkScreen);
 Screens.set(ADD_BOOKMARK_SCREEN, AddBookmarkScreen);
 Screens.set(HELP_SCREEN, HelpScreen)
 Screens.set(IMAGE_OPTIONS_SCREEN, ImageOptionsScreen);
+Screens.set(IMAGE_CROP_SCREEN, ImageCropScreen);
 Screens.set(REPLIES_SCREEN, RepliesScreen);
 Screens.set(REPLY_EDIT_SCREEN, ReplyEditScreen);
 Screens.set(SETTINGS_SCREEN, SettingsScreen);
@@ -767,6 +770,27 @@ export const imageOptionsScreen = (image, index, component_id) => {
           title: {
             text: "Image options"
           },
+        }
+      }
+    }
+  };
+
+  return Navigation.push(component_id, options);
+}
+
+export const imageCropScreen = (component_id) => {
+  console.log("Screens:imageCropScreen");
+  const options = {
+    component: {
+      id: IMAGE_CROP_SCREEN,
+      name: IMAGE_CROP_SCREEN,
+      passProps: {
+      },
+      options: {
+        topBar: {
+          title: {
+            text: "Photo"
+          }
         }
       }
     }

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -46,7 +46,7 @@ export const BOOKMARK_SCREEN = 'microblog.BookmarkScreen';
 export const ADD_BOOKMARK_SCREEN = 'microblog.modal.AddBookmarkScreen';
 export const HELP_SCREEN = 'microblog.modal.HelpScreen';
 export const IMAGE_OPTIONS_SCREEN = 'microblog.modal.ImageOptionsScreen';
-export const IMAGE_CROP_SCREEN = 'microblog.modal.ImageCropScreen';
+export const IMAGE_CROP_SCREEN = 'microblog.ImageCropScreen';
 export const REPLIES_SCREEN = 'micrblog.RepliesScreen';
 export const REPLY_EDIT_SCREEN = 'microblog.ReplyEditScreen';
 export const SETTINGS_SCREEN = 'microblog.modal.SettingsScreen';
@@ -778,19 +778,30 @@ export const imageOptionsScreen = (image, index, component_id) => {
   return Navigation.push(component_id, options);
 }
 
-export const imageCropScreen = (component_id) => {
+export const imageCropScreen = (asset, component_id) => {
   console.log("Screens:imageCropScreen");
+  
+  asset.save_to_temp()
+  
   const options = {
     component: {
       id: IMAGE_CROP_SCREEN,
       name: IMAGE_CROP_SCREEN,
       passProps: {
+        asset: asset
       },
       options: {
         topBar: {
           title: {
             text: "Photo"
-          }
+          },
+          rightButtons: [
+            {
+              id: 'add_photo_button',
+              text: 'Add Photo',
+              color: App.theme_accent_color()
+            }
+          ]
         }
       }
     }

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -30,13 +30,34 @@ export default class ImageCropScreen extends React.Component{
 		const { asset } = this.props
 		return (
 			<View style={{ flex: 1, flexDirection: "column" }}>
-				<View style={{ flex: 1, flexDirection: "row" }}>
-					<ScrollView style={{ width: "100%", height: scroll_size }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
-						this.setState({ scroll_size: e.nativeEvent.layout.width })
-					}}>
-						<Image source={{ uri: asset.uri }} style={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size, resizeMode: "contain" }} />
-					</ScrollView>
-				</View>
+				{ asset.is_landscape() ? 
+					(
+						is_cropped ? 
+							<View style={{ flex: 1, flexDirection: "row" }}>
+								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
+									this.setState({ scroll_size: e.nativeEvent.layout.width })
+								}}>
+									<Image source={{ uri: asset.uri }} style={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size, resizeMode: "contain" }} />
+								</ScrollView>
+							</View>
+						:
+							<View style={{ flex: 1, flexDirection: "row" }}>
+								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: scroll_size }} onLayout={(e) => {
+									this.setState({ scroll_size: e.nativeEvent.layout.width })
+								}}>
+									<Image source={{ uri: asset.uri }} style={{ width: scroll_size, height: scroll_size, resizeMode: "contain" }} />
+								</ScrollView>
+							</View>
+					)
+				:
+					<View style={{ flex: 1, flexDirection: "row" }}>
+						<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
+							this.setState({ scroll_size: e.nativeEvent.layout.width })
+						}}>
+							<Image source={{ uri: asset.uri }} style={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size, resizeMode: "contain" }} />
+						</ScrollView>
+					</View>
+				}
 				<View style={{ flex: 1, flexDirection: "row" }}>
 					<TouchableOpacity
 						key={ "toggle_square" }

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -2,9 +2,24 @@ import * as React from 'react';
 import { observer } from 'mobx-react';
 import { View, Text, Image } from 'react-native';
 import { Navigation } from 'react-native-navigation';
+import { Screens, POSTING_SCREEN } from '../../screens';
 
 @observer
 export default class ImageCropScreen extends React.Component{
+
+	constructor (props) {
+		super(props)
+		Navigation.events().bindComponent(this)
+	}
+
+	navigationButtonPressed = async ({ buttonId }) => {
+		console.log("navigationButtonPressed::", buttonId)
+		if (buttonId === "add_image_button") {
+			Auth.selected_user.posting.attach_asset(this.props.asset)
+			Navigation.pop(POSTING_SCREEN)
+		}
+	}
+  
   render() {
 	  const { asset } = this.props
 	  return (
@@ -13,4 +28,5 @@ export default class ImageCropScreen extends React.Component{
 		</View>
 	  )
   }
+
 }

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -1,15 +1,16 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { View, Text } from 'react-native';
+import { View, Text, Image } from 'react-native';
 import { Navigation } from 'react-native-navigation';
 
 @observer
 export default class ImageCropScreen extends React.Component{
   render() {
+	  const { asset } = this.props
 	  return (
-		  <View>
-		  	<Text>Hi</Text>
-		  </View>
+		<View>
+			<Image source={{ uri: asset.uri }} style={{ width: "100%", height: 300 }} />
+		</View>
 	  )
   }
 }

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -44,6 +44,7 @@ export default class ImageCropScreen extends React.Component{
 				}
 				ImageEditor.cropImage(this.props.asset.uri, crop_info).then(url => {
 					console.log("Cropped image", url)
+					this.props.asset.delete_file()
 					var media_asset = MediaAsset.create({
 						uri: url,
 						type: this.props.asset.type,

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { observer } from 'mobx-react';
+import { View, Text } from 'react-native';
+import { Navigation } from 'react-native-navigation';
+
+@observer
+export default class ImageCropScreen extends React.Component{
+  render() {
+	  return (
+		  <View>
+		  	<Text>Hi</Text>
+		  </View>
+	  )
+  }
+}

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -1,14 +1,17 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { View, Text, Image } from 'react-native';
+import { ScrollView, View, Text, Image, useWindowDimensions } from 'react-native';
 import { Navigation } from 'react-native-navigation';
 import { Screens, POSTING_SCREEN } from '../../screens';
 
 @observer
 export default class ImageCropScreen extends React.Component{
-
+	
 	constructor (props) {
 		super(props)
+		this.state = {
+			scroll_size: 0
+		}
 		Navigation.events().bindComponent(this)
 	}
 
@@ -20,13 +23,21 @@ export default class ImageCropScreen extends React.Component{
 		}
 	}
   
-  render() {
-	  const { asset } = this.props
-	  return (
-		<View>
-			<Image source={{ uri: asset.uri }} style={{ width: "100%", height: 300 }} />
-		</View>
-	  )
+	render() {
+		const { scroll_size } = this.state
+		const { asset } = this.props
+		return (
+			<View style={{ flex: 1, flexDirection: "column" }}>
+				<View style={{ flex: 1, flexDirection: "row" }}>
+					<ScrollView style={{ width: "100%", height: scroll_size }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
+						this.setState({ scroll_size: e.nativeEvent.layout.width })
+					}}>
+						<Image source={{ uri: asset.uri }} style={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size, resizeMode: "contain" }} />
+					</ScrollView>
+				</View>
+				<Text style={{ height: 100, color: "#FFF" }}>Testing.</Text>
+			</View>
+		)
   }
 
 }

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -70,7 +70,7 @@ export default class ImageCropScreen extends React.Component{
 					(
 						asset.is_landscape() ? 
 							<View style={{ flex: 1, flexDirection: "row" }}>
-								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
+								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: App.theme_crop_background_color() }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
 									this.setState({ scroll_size: e.nativeEvent.layout.width })
 								}} scrollEventThrottle={ 50 } onScroll={(e) => {
 									console.log("on scroll", e.nativeEvent.contentOffset.x, e.nativeEvent.contentOffset.y)
@@ -81,7 +81,7 @@ export default class ImageCropScreen extends React.Component{
 							</View>
 						:
 							<View style={{ flex: 1, flexDirection: "row" }}>
-								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: asset.scale_height_for_width(scroll_size) }} onLayout={(e) => {
+								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: App.theme_crop_background_color() }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: asset.scale_height_for_width(scroll_size) }} onLayout={(e) => {
 									this.setState({ scroll_size: e.nativeEvent.layout.width })
 								}} scrollEventThrottle={ 50 } onScroll={(e) => {
 									console.log("on scroll", e.nativeEvent.contentOffset.x, e.nativeEvent.contentOffset.y)
@@ -93,7 +93,7 @@ export default class ImageCropScreen extends React.Component{
 					)
 				:
 					<View style={{ flex: 1, flexDirection: "row" }}>
-						<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: scroll_size }} onLayout={(e) => {
+						<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: App.theme_crop_background_color() }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: scroll_size }} onLayout={(e) => {
 							this.setState({ scroll_size: e.nativeEvent.layout.width })
 						}}>
 							<Image source={{ uri: asset.uri }} style={{ width: scroll_size, height: scroll_size, resizeMode: "contain" }} />
@@ -105,7 +105,7 @@ export default class ImageCropScreen extends React.Component{
 					<View style={{ flex: 1, flexDirection: "row" }}>
 						<TouchableOpacity
 							key={ "toggle_square" }
-							style={{ height: 34, paddingLeft: 14, paddingRight: 14, marginTop: 40, marginBottom: 20, marginLeft: 12, marginRight: 12, flexDirection: "row", alignItems: "center", justifyContent: "center", backgroundColor: (is_cropped ? App.theme_button_background_color() : App.theme_button_disabled_background_color()), borderRadius: 25 }}
+							style={{ height: 34, paddingLeft: 14, paddingRight: 14, marginTop: 40, marginBottom: 20, marginLeft: 12, marginRight: 12, flexDirection: "row", alignItems: "center", justifyContent: "center", backgroundColor: (is_cropped ? App.theme_crop_button_background_color() : App.theme_button_disabled_background_color()), borderRadius: 25 }}
 							onPress={() => {
 								this.setState({ is_cropped: !is_cropped })
 							}}

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { ScrollView, View, Text, Image, useWindowDimensions } from 'react-native';
+import { ScrollView, View, Text, Image, TouchableOpacity } from 'react-native';
 import { Navigation } from 'react-native-navigation';
 import { Screens, POSTING_SCREEN } from '../../screens';
+import CheckmarkIcon from '../../assets/icons/checkmark.png';
 
 @observer
 export default class ImageCropScreen extends React.Component{
@@ -10,7 +11,8 @@ export default class ImageCropScreen extends React.Component{
 	constructor (props) {
 		super(props)
 		this.state = {
-			scroll_size: 0
+			scroll_size: 0,
+			is_cropped: true
 		}
 		Navigation.events().bindComponent(this)
 	}
@@ -24,7 +26,7 @@ export default class ImageCropScreen extends React.Component{
 	}
   
 	render() {
-		const { scroll_size } = this.state
+		const { scroll_size, is_cropped } = this.state
 		const { asset } = this.props
 		return (
 			<View style={{ flex: 1, flexDirection: "column" }}>
@@ -35,7 +37,20 @@ export default class ImageCropScreen extends React.Component{
 						<Image source={{ uri: asset.uri }} style={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size, resizeMode: "contain" }} />
 					</ScrollView>
 				</View>
-				<Text style={{ height: 100, color: "#FFF" }}>Testing.</Text>
+				<View style={{ flex: 1, flexDirection: "row" }}>
+					<TouchableOpacity
+						key={ "toggle_square" }
+						style={{ height: 34, paddingLeft: 14, paddingRight: 14, marginTop: 40, marginBottom: 20, marginLeft: 12, marginRight: 12, flexDirection: "row", alignItems: "center", justifyContent: "center", backgroundColor: (is_cropped ? App.theme_button_background_color() : App.theme_button_disabled_background_color()), borderRadius: 25 }}
+						onPress={() => {
+							this.setState({ is_cropped: !is_cropped })
+						}}
+					>
+						<Text style={{ color: (is_cropped ? App.theme_button_text_color() : App.theme_button_disabled_text_color()) }}>
+							Crop photo to square 
+							{ is_cropped ? <Image source={CheckmarkIcon} style={{ width: 12, height: 12, marginLeft: 5, tintColor: App.theme_button_text_color() }} /> : null }
+						</Text>
+					</TouchableOpacity>
+				</View>
 			</View>
 		)
   }

--- a/src/screens/posts/image_crop.js
+++ b/src/screens/posts/image_crop.js
@@ -30,9 +30,9 @@ export default class ImageCropScreen extends React.Component{
 		const { asset } = this.props
 		return (
 			<View style={{ flex: 1, flexDirection: "column" }}>
-				{ asset.is_landscape() ? 
+				{ is_cropped ? 
 					(
-						is_cropped ? 
+						asset.is_landscape() ? 
 							<View style={{ flex: 1, flexDirection: "row" }}>
 								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
 									this.setState({ scroll_size: e.nativeEvent.layout.width })
@@ -42,36 +42,39 @@ export default class ImageCropScreen extends React.Component{
 							</View>
 						:
 							<View style={{ flex: 1, flexDirection: "row" }}>
-								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: scroll_size }} onLayout={(e) => {
+								<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: asset.scale_height_for_width(scroll_size) }} onLayout={(e) => {
 									this.setState({ scroll_size: e.nativeEvent.layout.width })
 								}}>
-									<Image source={{ uri: asset.uri }} style={{ width: scroll_size, height: scroll_size, resizeMode: "contain" }} />
+									<Image source={{ uri: asset.uri }} style={{ width: scroll_size, height: asset.scale_height_for_width(scroll_size), resizeMode: "contain" }} />
 								</ScrollView>
 							</View>
 					)
 				:
 					<View style={{ flex: 1, flexDirection: "row" }}>
-						<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size }} onLayout={(e) => {
+						<ScrollView style={{ width: "100%", height: scroll_size, backgroundColor: "#000" }} bounces={ false } contentContainerStyle={{ width: scroll_size, height: scroll_size }} onLayout={(e) => {
 							this.setState({ scroll_size: e.nativeEvent.layout.width })
 						}}>
-							<Image source={{ uri: asset.uri }} style={{ width: asset.scale_width_for_height(scroll_size), height: scroll_size, resizeMode: "contain" }} />
+							<Image source={{ uri: asset.uri }} style={{ width: scroll_size, height: scroll_size, resizeMode: "contain" }} />
 						</ScrollView>
 					</View>
 				}
-				<View style={{ flex: 1, flexDirection: "row" }}>
-					<TouchableOpacity
-						key={ "toggle_square" }
-						style={{ height: 34, paddingLeft: 14, paddingRight: 14, marginTop: 40, marginBottom: 20, marginLeft: 12, marginRight: 12, flexDirection: "row", alignItems: "center", justifyContent: "center", backgroundColor: (is_cropped ? App.theme_button_background_color() : App.theme_button_disabled_background_color()), borderRadius: 25 }}
-						onPress={() => {
-							this.setState({ is_cropped: !is_cropped })
-						}}
-					>
-						<Text style={{ color: (is_cropped ? App.theme_button_text_color() : App.theme_button_disabled_text_color()) }}>
-							Crop photo to square 
-							{ is_cropped ? <Image source={CheckmarkIcon} style={{ width: 12, height: 12, marginLeft: 5, tintColor: App.theme_button_text_color() }} /> : null }
-						</Text>
-					</TouchableOpacity>
-				</View>
+				
+				{ !asset.is_square() ?
+					<View style={{ flex: 1, flexDirection: "row" }}>
+						<TouchableOpacity
+							key={ "toggle_square" }
+							style={{ height: 34, paddingLeft: 14, paddingRight: 14, marginTop: 40, marginBottom: 20, marginLeft: 12, marginRight: 12, flexDirection: "row", alignItems: "center", justifyContent: "center", backgroundColor: (is_cropped ? App.theme_button_background_color() : App.theme_button_disabled_background_color()), borderRadius: 25 }}
+							onPress={() => {
+								this.setState({ is_cropped: !is_cropped })
+							}}
+						>
+							<Text style={{ color: (is_cropped ? App.theme_button_text_color() : App.theme_button_disabled_text_color()) }}>
+								Crop photo to square 
+								{ is_cropped ? <Image source={CheckmarkIcon} style={{ width: 12, height: 12, marginLeft: 5, tintColor: App.theme_button_text_color() }} /> : null }
+							</Text>
+						</TouchableOpacity>
+					</View>
+				: null }
 			</View>
 		)
   }

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -603,6 +603,12 @@ export default App = types.model('App', {
   theme_button_text_color() {
     return self.theme === "dark" ? "#E5E7EB" : "#1F2937"
   },
+  theme_button_disabled_background_color() {
+    return self.theme === "dark" ? "#272d37" : "#F9FAFB"    
+  },
+  theme_button_disabled_text_color() {
+    return self.theme === "dark" ? "#a1a3a5" : "#1F2937"
+  },
   theme_section_background_color() {
     return self.theme === "dark" ? "#374151" : "#E5E7EB"
   },

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -607,7 +607,7 @@ export default App = types.model('App', {
     return self.theme === "dark" ? "#272d37" : "#F9FAFB"    
   },
   theme_button_disabled_text_color() {
-    return self.theme === "dark" ? "#a1a3a5" : "#1F2937"
+    return self.theme === "dark" ? "#a1a3a5" : "#4e6180"
   },
   theme_section_background_color() {
     return self.theme === "dark" ? "#374151" : "#E5E7EB"
@@ -635,6 +635,15 @@ export default App = types.model('App', {
   },
   theme_autocomplete_background_color() {
     return self.theme === "dark" ? "#1c2028" : "#f4f6f8"
+  },
+  theme_crop_button_text_color() {
+    return self.theme === "dark" ? "#E5E7EB" : "#000000"
+  },
+  theme_crop_button_background_color() {
+    return self.theme === "dark" ? "#374151" : "#d9dadb"
+  },
+  theme_crop_background_color() {
+    return self.theme === "dark" ? "#000000" : "#e5e5e5"    
   },
   should_reload_web_view() {
     // When it returns true, this will trigger a reload of the webviews

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -9,6 +9,7 @@ import MediaAsset from './posting/MediaAsset'
 import App from '../App'
 import Clipboard from '@react-native-clipboard/clipboard';
 import { imageOptionsScreen, POSTING_SCREEN } from '../../screens';
+import { imageCropScreen } from '../../screens';
 import { Navigation } from 'react-native-navigation';
 import md from 'markdown-it';
 const parser = md({ html: true });
@@ -196,6 +197,11 @@ export default Posting = types.model('Posting', {
         media_asset.upload(self.selected_service.service_object())
       })
     }
+  }),
+
+  handle_crop_action: flow(function* (component_id) {
+    console.log("Posting:handle_crop_action")
+    return imageCropScreen(component_id)
   }),
 
   asset_action: flow(function* (asset, index) {

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -194,11 +194,13 @@ export default Posting = types.model('Posting', {
         console.log("Posting:handle_image_action:asset", asset)
         const media_asset = MediaAsset.create(asset)
         imageCropScreen(media_asset, component_id)
-
-        // self.post_assets.push(media_asset)
-        // media_asset.upload(self.selected_service.service_object())
       })
     }
+  }),
+  
+  attach_asset: flow(function* (asset) {
+    self.post_assets.push(asset)
+    asset.upload(self.selected_service.service_object())
   }),
 
   asset_action: flow(function* (asset, index) {

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -171,7 +171,7 @@ export default Posting = types.model('Posting', {
     
   }),
 
-  handle_asset_action: flow(function* () {
+  handle_asset_action: flow(function* (component_id) {
     console.log("Posting:handle_asset_action")
     const options = {
       title: 'Select an image',
@@ -193,15 +193,12 @@ export default Posting = types.model('Posting', {
       result.assets.forEach((asset) => {
         console.log("Posting:handle_image_action:asset", asset)
         const media_asset = MediaAsset.create(asset)
-        self.post_assets.push(media_asset)
-        media_asset.upload(self.selected_service.service_object())
+        imageCropScreen(media_asset, component_id)
+
+        // self.post_assets.push(media_asset)
+        // media_asset.upload(self.selected_service.service_object())
       })
     }
-  }),
-
-  handle_crop_action: flow(function* (component_id) {
-    console.log("Posting:handle_crop_action")
-    return imageCropScreen(component_id)
   }),
 
   asset_action: flow(function* (asset, index) {

--- a/src/stores/models/posting/MediaAsset.js
+++ b/src/stores/models/posting/MediaAsset.js
@@ -65,6 +65,10 @@ export default MediaAsset = types.model('MediaAsset', {
 	
 	scale_width_for_height(height) {
 		return 600
+	},
+	
+	scale_height_for_height(width) {
+		return 600
 	}
   
 }))

--- a/src/stores/models/posting/MediaAsset.js
+++ b/src/stores/models/posting/MediaAsset.js
@@ -1,5 +1,6 @@
 import { types, flow } from 'mobx-state-tree';
 import MicroPubApi, { POST_ERROR } from './../../../api/MicroPubApi';
+const FS = require("react-native-fs")
 
 export default MediaAsset = types.model('MediaAsset', {
 	uri: types.identifier,
@@ -25,6 +26,14 @@ export default MediaAsset = types.model('MediaAsset', {
 	set_alt_text: flow(function* (text) {
 		console.log("MediaAsset:set_alt_text", text)
 		self.alt_text = text
+	}),
+	
+	save_to_temp: flow(function* () {
+		const filename = (Math.floor(Math.random() * 10000)).toString()
+		const new_path = FS.TemporaryDirectoryPath + "/" + filename
+		console.log("MediaAsset:save_to_temp", new_path)
+		FS.copyFile(self.uri, new_path)
+		self.uri = "file://" + new_path
 	})
 
 }))

--- a/src/stores/models/posting/MediaAsset.js
+++ b/src/stores/models/posting/MediaAsset.js
@@ -50,6 +50,11 @@ export default MediaAsset = types.model('MediaAsset', {
 		
 		return promise
 	},
+	
+	async delete_file() {
+		const path = self.uri.replace("file://", "")
+		FS.unlink(path)
+	},
   
 	file_extension() {
 		if (self.type === "image/png") {

--- a/src/stores/models/posting/MediaAsset.js
+++ b/src/stores/models/posting/MediaAsset.js
@@ -5,6 +5,8 @@ const FS = require("react-native-fs")
 export default MediaAsset = types.model('MediaAsset', {
 	uri: types.identifier,
 	type: types.maybe(types.string),
+	width: types.optional(types.number, 0),
+	height: types.optional(types.number, 0),
 	is_uploading: types.optional(types.boolean, false),
 	did_upload: types.optional(types.boolean, false),
 	remote_url: types.maybe(types.string),
@@ -37,7 +39,9 @@ export default MediaAsset = types.model('MediaAsset', {
 
 		var new_asset = MediaAsset.create({
 			uri: "file://" + new_path,
-			type: self.type
+			type: self.type,
+			width: self.width,
+			height: self.height
 		})
 
 		var promise = FS.copyFile(self.uri, new_path).then((result) => {
@@ -60,15 +64,23 @@ export default MediaAsset = types.model('MediaAsset', {
 	},
 	
 	is_landscape() {
-		return true
+		return self.width > self.height
+	},
+
+	is_portrait() {
+		return self.height > self.width
 	},
 	
-	scale_width_for_height(height) {
-		return 600
+	is_square() {
+		return self.width == self.height
 	},
 	
-	scale_height_for_height(width) {
-		return 600
+	scale_width_for_height(new_height) {
+		return self.width / self.height * new_height
+	},
+	
+	scale_height_for_width(new_width) {
+		return self.height / self.width * new_width
 	}
   
 }))

--- a/src/stores/models/posting/MediaAsset.js
+++ b/src/stores/models/posting/MediaAsset.js
@@ -26,14 +26,37 @@ export default MediaAsset = types.model('MediaAsset', {
 	set_alt_text: flow(function* (text) {
 		console.log("MediaAsset:set_alt_text", text)
 		self.alt_text = text
-	}),
-	
-	save_to_temp: flow(function* () {
-		const filename = (Math.floor(Math.random() * 10000)).toString()
-		const new_path = FS.TemporaryDirectoryPath + "/" + filename
-		console.log("MediaAsset:save_to_temp", new_path)
-		FS.copyFile(self.uri, new_path)
-		self.uri = "file://" + new_path
 	})
 
+}))
+.views(self => ({
+
+	async save_to_temp() {
+		const filename = (Math.floor(Math.random() * 10000)).toString() + self.file_extension()
+		const new_path = FS.TemporaryDirectoryPath + filename
+
+		var new_asset = MediaAsset.create({
+			uri: "file://" + new_path,
+			type: self.type
+		})
+
+		var promise = FS.copyFile(self.uri, new_path).then((result) => {
+			return new_asset
+		})
+		
+		return promise
+	},
+  
+	file_extension() {
+		if (self.type === "image/png") {
+			return ".png"			
+		}
+		else if (self.type === "image/gif") {
+			return ".gif"
+		}
+		else {
+			return ".jpg"
+		}
+	}
+  
 }))

--- a/src/stores/models/posting/MediaAsset.js
+++ b/src/stores/models/posting/MediaAsset.js
@@ -57,6 +57,14 @@ export default MediaAsset = types.model('MediaAsset', {
 		else {
 			return ".jpg"
 		}
+	},
+	
+	is_landscape() {
+		return true
+	},
+	
+	scale_width_for_height(height) {
+		return 600
 	}
   
 }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1646,6 +1646,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.3.0.tgz#9e558170c106bbafaa1ef502bd8e6d4651012bf9"
   integrity sha512-+zDZ20NUnSWghj7Ku5aFphMzuM9JulqCW+aPXT6IfIXFbb8tzYTTOSeRFOtuekJ99ibW2fUCSsjuKNlwDIbHFg==
 
+"@react-native-community/image-editor@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/image-editor/-/image-editor-2.3.0.tgz#8ac6c3691fd2c762d2abeb84c01a3b201bac3b1e"
+  integrity sha512-+UJY8WkTkfSkjoU5blQnEI7tTg11jJLoM+YojjiQpEopUaRlYQU4SZ9Zd6F6wWfvc9bjvIeMY6FlKuESK/q4fQ==
+
 "@react-native-community/netinfo@^9.0.0":
   version "9.3.7"
   resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.7.tgz#92407f679f00bae005c785a9284e61d63e292b34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2326,6 +2326,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base-64@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
+  integrity sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==
+
 base64-js@^1.1.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -6042,6 +6047,14 @@ react-native-fast-image@^8.5.11:
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.6.3.tgz#6edc3f9190092a909d636d93eecbcc54a8822255"
   integrity sha512-Sdw4ESidXCXOmQ9EcYguNY2swyoWmx53kym2zRsvi+VeFCHEdkO+WG1DK+6W81juot40bbfLNhkc63QnWtesNg==
 
+react-native-fs@^2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"
+  integrity sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==
+  dependencies:
+    base-64 "^0.1.0"
+    utf8 "^3.0.0"
+
 react-native-gesture-handler@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.9.0.tgz#2f63812e523c646f25b9ad660fc6f75948e51241"
@@ -7170,6 +7183,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This is something I wanted to preserve from the 2.3 version, but with improvements. When attaching a photo, there's an extra screen that previews it with default square cropping. There's a new button to toggle this that is much more obvious than in 2.3.

No filters yet, but considering adding a few built-in ones later.