### PR TITLE
Fix/share selected text

### DIFF
--- a/ios/MicroBlog_RN.xcodeproj/project.pbxproj
+++ b/ios/MicroBlog_RN.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4B1233D829ECD7D200174307 /* MBHighlightingTextStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B1233D529ECD7D200174307 /* MBHighlightingTextStorage.m */; };
 		4B7619D129EC9E7A0030A495 /* MBHighlightingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B7619D029EC9E7A0030A495 /* MBHighlightingTextView.m */; };
 		4B7619D229EC9E7A0030A495 /* MBHighlightingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B7619D029EC9E7A0030A495 /* MBHighlightingTextView.m */; };
+		4B8CE8AB2A1FCC69006D79CF /* GetURL.js in Resources */ = {isa = PBXBuildFile; fileRef = 4B8CE8AA2A1FCC69006D79CF /* GetURL.js */; };
 		52509892FFF0C47000E8F5DE /* libPods-MicroBlog_RN-MicroBlog_RNTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 60EE2B6292F1F3ED4E3AD989 /* libPods-MicroBlog_RN-MicroBlog_RNTests.a */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		8C619CFF939F9E33E65A6DAA /* libPods-MicroBlog_RN.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A1AD34313DED25C45B534DA /* libPods-MicroBlog_RN.a */; };
@@ -89,6 +90,7 @@
 		4B1233D629ECD7D200174307 /* MBHighlightingTextStorage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MBHighlightingTextStorage.h; path = MicroBlog_RN/MBHighlightingTextStorage.h; sourceTree = "<group>"; };
 		4B7619CF29EC9E7A0030A495 /* MBHighlightingTextView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MBHighlightingTextView.h; path = MicroBlog_RN/MBHighlightingTextView.h; sourceTree = "<group>"; };
 		4B7619D029EC9E7A0030A495 /* MBHighlightingTextView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = MBHighlightingTextView.m; path = MicroBlog_RN/MBHighlightingTextView.m; sourceTree = "<group>"; };
+		4B8CE8AA2A1FCC69006D79CF /* GetURL.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = GetURL.js; sourceTree = "<group>"; };
 		4C096FE28E3BF256DF2F0398 /* Pods-MicroBlog_RN-MicroBlog_RNTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MicroBlog_RN-MicroBlog_RNTests.release.xcconfig"; path = "Target Support Files/Pods-MicroBlog_RN-MicroBlog_RNTests/Pods-MicroBlog_RN-MicroBlog_RNTests.release.xcconfig"; sourceTree = "<group>"; };
 		60EE2B6292F1F3ED4E3AD989 /* libPods-MicroBlog_RN-MicroBlog_RNTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MicroBlog_RN-MicroBlog_RNTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		67F5CB031FE91036DC73F2D9 /* Pods-MicroBlog_RN-MicroBlog_Share.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MicroBlog_RN-MicroBlog_Share.debug.xcconfig"; path = "Target Support Files/Pods-MicroBlog_RN-MicroBlog_Share/Pods-MicroBlog_RN-MicroBlog_Share.debug.xcconfig"; sourceTree = "<group>"; };
@@ -154,6 +156,7 @@
 				0221AB2829D42C1500838597 /* MainInterface.storyboard */,
 				0221AB2B29D42C1500838597 /* Info.plist */,
 				0221AB3329D42CE400838597 /* MicroBlog_Share-Bridging-Header.h */,
+				4B8CE8AA2A1FCC69006D79CF /* GetURL.js */,
 			);
 			path = MicroBlog_Share;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0221AB2A29D42C1500838597 /* MainInterface.storyboard in Resources */,
+				4B8CE8AB2A1FCC69006D79CF /* GetURL.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/MicroBlog_Share/GetURL.js
+++ b/ios/MicroBlog_Share/GetURL.js
@@ -1,0 +1,11 @@
+var MyExtensionJavaScriptClass = function() {};
+
+MyExtensionJavaScriptClass.prototype = {
+run: function(arguments) {
+  // Pass the baseURI of the webpage to the extension.
+  arguments.completionFunction({"title": document.title, "url": document.URL, "text": document.getSelection().toString()});
+}
+};
+
+// The JavaScript file must contain a global object named "ExtensionPreprocessingJS".
+var ExtensionPreprocessingJS = new MyExtensionJavaScriptClass;

--- a/ios/MicroBlog_Share/Info.plist
+++ b/ios/MicroBlog_Share/Info.plist
@@ -18,7 +18,11 @@
 				<true/>
 				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
 				<integer>1</integer>
+				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
+				<integer>1</integer>
 			</dict>
+			<key>NSExtensionJavaScriptPreprocessingFile</key>
+			<string>GetURL</string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/patches/react-native-share-menu+6.0.0.patch
+++ b/patches/react-native-share-menu+6.0.0.patch
@@ -1,3 +1,36 @@
+diff --git a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
+index e290cce..f267c3d 100644
+--- a/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
++++ b/node_modules/react-native-share-menu/ios/Modules/ShareMenuReactView.swift
+@@ -159,9 +159,26 @@ public class ShareMenuReactView: NSObject {
+                         semaphore.wait()
+                     } else if provider.hasItemConformingToTypeIdentifier(kUTTypeData as String) {
+                         provider.loadItem(forTypeIdentifier: kUTTypeData as String, options: nil) { (item, error) in
+-                            let url: URL! = item as? URL
++                            let url_item = item
++                            let url: URL! = url_item as? URL
++                            
++                            if url != nil {
++                                results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                            }
++                            else if let itemDictionary = item as? NSDictionary,
++                                        let preprocessingResults = itemDictionary["NSExtensionJavaScriptPreprocessingResultsKey"] as? NSDictionary {
++                                         
++                                         let data = ["title": preprocessingResults["title"],
++                                                     "url": preprocessingResults["url"],
++                                                     "text": preprocessingResults["text"]]
++                                
+                                          
+-                            results.append([DATA_KEY: url.absoluteString, MIME_TYPE_KEY: self.extractMimeType(from: url)])
++                                         if let jsonData = try? JSONSerialization.data(withJSONObject: data),
++                                            let jsonString = String(data: jsonData, encoding: .utf8) {
++                                             // jsonString is the string representation of the preprocessing results
++                                             results.append([DATA_KEY: jsonString, MIME_TYPE_KEY: "application/json"])
++                                         }
++                                     }
+ 
+                             semaphore.signal()
+                         }
 diff --git a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift b/node_modules/react-native-share-menu/ios/ReactShareViewController.swift
 index f42bce6..ee36062 100644
 --- a/node_modules/react-native-share-menu/ios/ReactShareViewController.swift

--- a/src/stores/Share.js
+++ b/src/stores/Share.js
@@ -78,6 +78,9 @@ export default Share = types.model('Share', {
 			if (mime_type === "image/jpeg" || mime_type === "image/png") {
 				self.share_type = "image"
 			}
+			else if(mime_type === "application/json"){
+				self.share_type = "json"
+			}
 			if (self.share_type === "text") {
 				self.share_text = string_checker._validate_url(data) ? data : `> ${data}`
 				self.users.forEach(user => {
@@ -93,6 +96,22 @@ export default Share = types.model('Share', {
 				self.share_image_data = image_data
 				self.users.forEach(user => {
 					user.posting.create_and_attach_asset(image_data)
+				})
+			}
+			else if (self.share_type === "json"){
+				// Because we're dealing with JSON, we need to check a few things and add the correct share_text
+				const parsed_data = JSON.parse(data)
+				
+				let share_text = parsed_data.text ? `> ${parsed_data.text}\n\n` : "";
+				if (parsed_data.title && parsed_data.url) {
+						share_text += `[${parsed_data.title}](${parsed_data.url})`
+				} else if (parsed_data.url) {
+						share_text += `[](${parsed_data.url})`
+				}
+				
+				self.share_text = share_text
+				self.users.forEach(user => {
+					user.posting.set_post_text(self.share_text)
 				})
 			}
 			else {


### PR DESCRIPTION
This change, fixes issue: #40.

There is a patch for react-native-share-meu that handles the extra data received from the new JS file that is included.

The crashing issue was because it expected, and force unwrapped a URL, which was not the case with the extra data sent.

We now check for this. In addition, we also handle JSON data correctly in the JS side of things.