### PR TITLE
Fix improper truncation of emojis in short bio

### DIFF
--- a/src/components/profile/profile_header.js
+++ b/src/components/profile/profile_header.js
@@ -59,7 +59,18 @@ export default class ProfileHeader extends React.Component{
   _render_profile = () => {
     const { profile, more_expanded } = this.state;
     const long_bio = profile._microblog.bio ? profile._microblog.bio.trim().replace(/&amp;/g, "&") : null
-    const short_bio = long_bio ? long_bio.slice(0, 90).replace(/\n/g, " ") : null
+
+    // Prevent emojis from being improperly split
+    const EBNF_regex =
+      /\p{RI}\p{RI}|\p{Emoji}(\p{EMod}|\u{FE0F}\u{20E3}?|[\u{E0020}-\u{E007E}]+\u{E007F})?(\u{200D}\p{Emoji}(\p{EMod}|\u{FE0F}\u{20E3}?|[\u{E0020}-\u{E007E}]+\u{E007F})?)*|./gsu;
+    const short_bio = long_bio
+      ? long_bio
+          .match(EBNF_regex)
+          .slice(0, 90)
+          .join('')
+          .replace(/\n/g, ' ')
+      : null;
+
     const show_expand_option = long_bio?.length > short_bio?.length
     return(
       <View style={{ padding: 12, backgroundColor: App.theme_button_background_color(), width: '100%' }}>


### PR DESCRIPTION
Because emojis are technically multiple characters, the previous split method had the potential to break the rendering of them. I noticed this issue when viewing this profile:

<img src="https://github.com/microdotblog/microblog-react/assets/140852203/030ac8f2-a18e-4a10-b7e5-6c24b3c39e6e" width="300">

To fix this, I matched the emojis with regex using Unicode's "[EBNF rules](https://unicode.org/reports/tr51/#EBNF_and_Regex)". I ultimately got the pattern from [this](https://stackoverflow.com/a/70525152) StackOverflow answer.

This was a lot trickier to fix than I expected it to be — it seems JavaScript isn't well prepared to handle this edge case. There are a number of libraries that solve this, but I figured solving this without depending on a library would be best.

Here's what my fix looks like:

<img src="https://github.com/microdotblog/microblog-react/assets/140852203/4bd6c037-2833-46d5-b74e-fc7511a74032" width="300">

I went through a number of others' profiles to ensure that the truncation still behaves as expected. As far as I saw, it does.

<br>

Also,  is Prettier used for this app? My editor was picking up on the [.prettierrc.js](https://github.com/microdotblog/microblog-react/blob/main/.prettierrc.js) file in this repo, but it seems the files aren't formatted using it.