### PR TITLE
Revamp image options screen

### DIFF
--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -485,7 +485,7 @@ export const conversationScreen = (conversation_id, component_id) => {
         }
       }
     };
-    
+
     return Navigation.push(component_id, options);
   }
 }
@@ -714,7 +714,7 @@ export const addBoomarkScreen = () => {
       children: [ {
         component: {
           id: ADD_BOOKMARK_SCREEN,
-          name: ADD_BOOKMARK_SCREEN,          
+          name: ADD_BOOKMARK_SCREEN,
           options: {
             topBar: {
               title: {
@@ -772,6 +772,7 @@ export const helpScreen = () => {
 
 export const imageOptionsScreen = (asset, index, component_id) => {
   console.log("Screens:imageOptionsScreen", asset, index, component_id);
+
   const options = {
     component: {
       id: IMAGE_OPTIONS_SCREEN,
@@ -785,6 +786,13 @@ export const imageOptionsScreen = (asset, index, component_id) => {
           title: {
             text: asset.is_video ? "Video options" : "Image options"
           },
+          rightButtons: [
+            {
+               id: 'removeImage',
+               text: "Remove",
+               color: 'red',
+            }
+          ]
         }
       }
     }
@@ -795,9 +803,9 @@ export const imageOptionsScreen = (asset, index, component_id) => {
 
 export const imageCropScreen = async (asset, component_id) => {
   console.log("Screens:imageCropScreen");
-  
+
   const new_asset = await asset.save_to_temp()
-  
+
   const options = {
     component: {
       id: IMAGE_CROP_SCREEN,

--- a/src/screens/index.js
+++ b/src/screens/index.js
@@ -788,7 +788,7 @@ export const imageOptionsScreen = (asset, index, component_id) => {
           },
           rightButtons: [
             {
-               id: 'removeImage',
+               id: 'remove_image',
                text: "Remove",
                color: 'red',
             }

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -64,16 +64,17 @@ export default class ImageOptionsScreen extends React.Component{
     }
 
     return(
-      <KeyboardAvoidingView behavior={"padding"} style={{ flex: 1 }}>
-        <ScrollView contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%", }}>
+      <KeyboardAvoidingView behavior={"padding"} style={{ flex: 1, backgroundColor: App.theme_button_background_color() }}>
+        <ScrollView contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%" }}>
           <View
             style={{
+              flex: 1,
+              width: '100%',
+              height: '100%',
               position: 'relative',
               justifyContent: 'center',
               alignItems: 'center',
-              width: media_width,
-              height: media_height,
-              backgroundColor: '#E5E7EB'
+              backgroundColor: App.theme_background_color(),
             }}
           >
             {

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -37,6 +37,14 @@ export default class ImageOptionsScreen extends React.Component{
     const { posting } = Auth.selected_user
     const { asset, index } = this.props
     const windowWidth = Dimensions.get('window').width;
+
+    let mediaWidth = windowWidth;
+    let mediaHeight = windowWidth; // default to 1:1
+    if (asset.width && asset.height) {
+      mediaWidth = windowWidth;
+      mediaHeight = windowWidth / (asset.width / asset.height);
+    }
+
     return(
       <KeyboardAvoidingView behavior={"position"} style={{ flex: 1 }}>
         <ScrollView style={{ padding: 15 }} contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%" }}>

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -10,6 +10,17 @@ import Video from 'react-native-video';
 @observer
 export default class ImageOptionsScreen extends React.Component{
 
+  constructor(props) {
+    super(props);
+    Navigation.events().registerNavigationButtonPressedListener(({ buttonId }) => {
+      if (buttonId === 'removeImage') {
+        const { asset, index } = this.props
+          this._handle_image_remove(asset, index)
+      }
+    });
+  }
+  
+
   _handle_image_remove = (image, index) => {
     const { posting } = Auth.selected_user
     const existing_index = posting.post_assets?.findIndex(file => file.uri === image.uri)
@@ -35,7 +46,7 @@ export default class ImageOptionsScreen extends React.Component{
 
   render() {
     const { posting } = Auth.selected_user
-    const { asset, index } = this.props
+    const { asset } = this.props
     const windowWidth = Dimensions.get('window').width;
 
     let mediaWidth = windowWidth;
@@ -122,27 +133,9 @@ export default class ImageOptionsScreen extends React.Component{
               onChangeText={(text) => !posting.is_sending_post ? asset.set_alt_text(text) : null}
             />
           }
-          <View
-            style={{
-              width: "100%",
-            }}
-          >
-            <TouchableOpacity
-              onPress={() => this._handle_image_remove(asset, index)}
-              key={asset.uri}
-              style={{
-                justifyContent: 'center',
-                alignItems: 'center',
-                marginVertical: asset.is_video ? 25 : 0,
-              }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', width: "100%", justifyContent: 'center' }}>
-                <Text style={{color: 'red'}}>{asset.is_uploading ? "Cancel Upload & Remove" : "Remove"}</Text>
-              </View>
-            </TouchableOpacity>
-          </View>
         </ScrollView>
       </KeyboardAvoidingView>
     )
   }
-  
+
 }

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -13,7 +13,7 @@ export default class ImageOptionsScreen extends React.Component{
   constructor(props) {
     super(props);
     Navigation.events().registerNavigationButtonPressedListener(({ buttonId }) => {
-      if (buttonId === 'removeImage') {
+      if (buttonId === 'remove_image') {
         const { asset, index } = this.props
           this._handle_image_remove(asset, index)
       }
@@ -48,16 +48,18 @@ export default class ImageOptionsScreen extends React.Component{
     const { posting } = Auth.selected_user
     const { asset } = this.props
     
-    const maxMediaHeight = 300; // cap media height
-    const windowWidth = Dimensions.get('window').width;
-    let mediaWidth = windowWidth;
-    let mediaHeight = windowWidth; // default to 1:1
+    const max_media_height = 300; // cap media height
+    const window_width = Dimensions.get('window').width;
+    let media_width = window_width;
+    let media_height = window_width; // default to 1:1
+
     if (asset.width && asset.height) {
-      mediaWidth = windowWidth;
-      mediaHeight = windowWidth / (asset.width / asset.height);
-      if (mediaHeight > maxMediaHeight) {
-        mediaHeight = maxMediaHeight;
-        mediaWidth = asset.width * (maxMediaHeight / asset.height);
+      const aspect_ratio = asset.width / asset.height;
+      media_height = window_width / aspect_ratio;
+      
+      if (media_height > max_media_height) {
+        media_height = max_media_height;
+        media_width = max_media_height * aspect_ratio;
       }
     }
 
@@ -69,8 +71,8 @@ export default class ImageOptionsScreen extends React.Component{
               position: 'relative',
               justifyContent: 'center',
               alignItems: 'center',
-              width: mediaWidth,
-              height: mediaHeight,
+              width: media_width,
+              height: media_height,
               backgroundColor: '#E5E7EB'
             }}
           >
@@ -78,14 +80,14 @@ export default class ImageOptionsScreen extends React.Component{
               asset.is_video ?
               <Video
                 source={{ uri: asset.uri }}
-                poster={asset.remote_poster_url ? asset.remote_poster_url : asset.uri} style={{width: mediaWidth, height: mediaHeight}}
+                poster={asset.remote_poster_url ? asset.remote_poster_url : asset.uri} style={{width: media_width, height: media_height}}
                 mixWithOthers={"mix"}
                 controls
                 repeat
               />
               // <Image source={{ uri: asset.remote_poster_url ? asset.remote_poster_url : asset.uri }} style={{ width: 250, height: 250, borderRadius: 5 }} />
               :
-              <Image source={{ uri: asset.remote_url ? asset.remote_url : asset.uri }} style={{ width: mediaWidth, height: mediaHeight }} />
+              <Image source={{ uri: asset.remote_url ? asset.remote_url : asset.uri }} style={{ width: media_width, height: media_height }} />
             }
             {
               asset.is_uploading ?

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -47,13 +47,18 @@ export default class ImageOptionsScreen extends React.Component{
   render() {
     const { posting } = Auth.selected_user
     const { asset } = this.props
+    
+    const maxMediaHeight = 300; // cap media height
     const windowWidth = Dimensions.get('window').width;
-
     let mediaWidth = windowWidth;
     let mediaHeight = windowWidth; // default to 1:1
     if (asset.width && asset.height) {
       mediaWidth = windowWidth;
       mediaHeight = windowWidth / (asset.width / asset.height);
+      if (mediaHeight > maxMediaHeight) {
+        mediaHeight = maxMediaHeight;
+        mediaWidth = asset.width * (maxMediaHeight / asset.height);
+      }
     }
 
     return(

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -57,7 +57,7 @@ export default class ImageOptionsScreen extends React.Component{
     }
 
     return(
-      <KeyboardAvoidingView behavior={"position"} style={{ flex: 1 }}>
+      <KeyboardAvoidingView behavior={"padding"} style={{ flex: 1 }}>
         <ScrollView style={{ padding: 15 }} contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%" }}>
           <View
             style={{

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -3,12 +3,13 @@ import { observer } from 'mobx-react';
 import { View, Text, TouchableOpacity, ScrollView, Image, ActivityIndicator, TextInput, KeyboardAvoidingView, Alert } from 'react-native';
 import Auth from '../../stores/Auth';
 import App from '../../stores/App'
+import { Dimensions } from 'react-native';
 import { Navigation } from 'react-native-navigation';
 import Video from 'react-native-video';
 
 @observer
 export default class ImageOptionsScreen extends React.Component{
-  
+
   _handle_image_remove = (image, index) => {
     const { posting } = Auth.selected_user
     const existing_index = posting.post_assets?.findIndex(file => file.uri === image.uri)
@@ -31,10 +32,11 @@ export default class ImageOptionsScreen extends React.Component{
       );
     }
   }
-  
+
   render() {
     const { posting } = Auth.selected_user
     const { asset, index } = this.props
+    const windowWidth = Dimensions.get('window').width;
     return(
       <KeyboardAvoidingView behavior={"position"} style={{ flex: 1 }}>
         <ScrollView style={{ padding: 15 }} contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%" }}>

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -93,23 +93,17 @@ export default class ImageOptionsScreen extends React.Component{
               asset.is_uploading ?
                 <>
                   <ActivityIndicator color="#f80" size={"large"} style={{ position: 'absolute' }} />
-                  <View
-                    style={{
-                      width: `${ asset.progress }%`,
-                      height: 5,
-                      backgroundColor: App.theme_accent_color(),
-                      position: 'absolute',
-                      left: 0,
-                      bottom: 0,
-                      borderBottomLeftRadius: 5,
-                      borderBottomRightRadius: asset.progress === 100 ? 5 : 0,
-                      zIndex: 2
-                    }}
-                  />
                 </>
               : null
             }
           </View>
+          <View
+            style={{
+              width: `${ asset.progress }%`,
+              height: 5,
+              backgroundColor: asset.is_uploading ? App.theme_accent_color() : "transparent",
+            }}
+          />
           {
             !asset.is_video &&
             <TextInput
@@ -118,8 +112,8 @@ export default class ImageOptionsScreen extends React.Component{
               style={{
                 fontSize: 20,
                 padding: 9,
-                paddingTop: 13,
-                paddingBottom: 143,
+                paddingTop: 9,
+                paddingBottom: 143, // enlarge textinput click area; arbitrary number
                 fontWeight: '400',
                 color: App.theme_text_color(),
                 width: "100%",

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -53,23 +53,23 @@ export default class ImageOptionsScreen extends React.Component{
               position: 'relative',
               justifyContent: 'center',
               alignItems: 'center',
-              width: 250,
-              height: 250,
+              width: mediaWidth,
+              height: mediaHeight,
               backgroundColor: '#E5E7EB'
             }}
           >
             {
               asset.is_video ?
-              <Video 
+              <Video
                 source={{ uri: asset.uri }}
-                poster={asset.remote_poster_url ? asset.remote_poster_url : asset.uri} style={{width: 250, height: 250}}
+                poster={asset.remote_poster_url ? asset.remote_poster_url : asset.uri} style={{width: mediaWidth, height: mediaHeight}}
                 mixWithOthers={"mix"}
                 controls
                 repeat
               />
               // <Image source={{ uri: asset.remote_poster_url ? asset.remote_poster_url : asset.uri }} style={{ width: 250, height: 250, borderRadius: 5 }} />
               :
-              <Image source={{ uri: asset.remote_url ? asset.remote_url : asset.uri }} style={{ width: 250, height: 250, borderRadius: 5 }} />
+              <Image source={{ uri: asset.remote_url ? asset.remote_url : asset.uri }} style={{ width: mediaWidth, height: mediaHeight }} />
             }
             {
               asset.is_uploading ?

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -58,7 +58,7 @@ export default class ImageOptionsScreen extends React.Component{
 
     return(
       <KeyboardAvoidingView behavior={"padding"} style={{ flex: 1 }}>
-        <ScrollView style={{ padding: 15 }} contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%" }}>
+        <ScrollView contentContainerStyle={{ justifyContent: 'center', alignItems: 'center', width: "100%", }}>
           <View
             style={{
               position: 'relative',
@@ -111,17 +111,15 @@ export default class ImageOptionsScreen extends React.Component{
               style={{
                 fontSize: 20,
                 padding: 9,
-                paddingTop: 9,
+                paddingTop: 13,
+                paddingBottom: 143,
                 fontWeight: '400',
                 color: App.theme_text_color(),
-                marginVertical: 25,
-                borderRadius: 5,
-                backgroundColor: App.theme_button_background_color(),
-                width: "100%"
+                width: "100%",
               }}
               editable={!posting.is_sending_post}
               multiline={true}
-              scrollEnabled={true}
+              scrollEnabled={false}
               returnKeyType={'default'}
               keyboardType={'default'}
               autoFocus={false}


### PR DESCRIPTION
I found adding alt text to be a subpar experience. These changes aim to improve it:

- Media display is now dynamically sized
  - Takes up max width up to a height of 300px
- Alt text input box now takes up the rest of the view
- Remove button has been moved to the topBar
- Keyboard behavior changed to "padding" to prevent image from being pushed up even with a small amount of text

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/microdotblog/microblog-react/assets/140852203/81371e75-2969-49d5-a190-23280c6852cb)  |  ![](https://github.com/microdotblog/microblog-react/assets/140852203/168e89d9-6edc-43e5-a1a3-f71e271e008c)

<br>

Notes:
- I have not tested this on Android. If all looks good, I can set up an Android simulator to confirm it works. Theoretically should work
- I have not tested video because I don't pay for Premium. Theoretically should work