### PR TITLE
Check if conversation screen is open before navigating to a new screen.

### DIFF
--- a/src/screens/stacks/SharedStack.js
+++ b/src/screens/stacks/SharedStack.js
@@ -12,7 +12,7 @@ import RepliesScreen from '../replies/replies';
 import PagesScreen from '../pages/pages';
 import PostsScreen from '../posts/posts';
 import NewPostButton from '../../components/header/new_post';
-
+import App from '../../stores/App'
 
 export const getSharedScreens = (Stack, tab_name) => {
 	return [
@@ -32,6 +32,14 @@ export const getSharedScreens = (Stack, tab_name) => {
 			options={({ route }) => ({
 				headerTitle: `Conversation`,
 				headerRight: () => <ReplyButton conversation_id={route.params?.conversation_id} />
+			})}
+			listeners={() => ({
+				focus: () => {
+					App.set_conversation_screen_focused(true)
+				},
+				blur: () => {
+					App.set_conversation_screen_focused(false)
+				}
 			})}
 		/>,
 		<Stack.Screen

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -48,7 +48,8 @@ export default App = types.model('App', {
   uploads_search_query: types.optional(types.string, ""),
   is_searching_uploads: types.optional(types.boolean, false),
   is_loading_highlights: types.optional(types.boolean, false),
-  is_loading_bookmarks: types.optional(types.boolean, false)
+  is_loading_bookmarks: types.optional(types.boolean, false),
+  conversation_screen_focused: types.optional(types.boolean, false)
 })
 .volatile(self => ({
   navigation_ref: null,
@@ -182,6 +183,10 @@ export default App = types.model('App', {
     }
   }),
 
+  set_conversation_screen_focused: flow(function* (focused = true) {
+    self.conversation_screen_focused = focused
+  }),
+
   handle_url: flow(function* (url) {
     console.log("App:handle_url", url)
     const url_parts = url.split("://")
@@ -226,6 +231,9 @@ export default App = types.model('App', {
         case "open":
           Reply.hydrate(action_data)
           Push.check_and_remove_notifications_with_post_id(action_data)
+          if (self.conversation_screen_focused) {
+            return self.navigation_ref.navigate(`${self.current_tab_key}-Conversation`, { conversation_id: action_data })
+          }
           return self.navigation_ref.push(`${self.current_tab_key}-Conversation`, { conversation_id: action_data })
         case "post_service":
           yield Services.hydrate_with_user(action_data)


### PR DESCRIPTION
This updates the current conversation instead of pushing to a new screen if the screen is currently in focus.

This functionality was lost during the navigation migration.