### PR TITLE
Better push prompts and logic. Remove production console logs.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,5 +3,10 @@ module.exports = {
   plugins: [
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     'react-native-reanimated/plugin'
-  ]
+  ],
+  env: {
+    production: {
+      plugins: ['transform-remove-console']
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",
     "patch-package": "^6.4.7",

--- a/src/screens/mentions/mentions.js
+++ b/src/screens/mentions/mentions.js
@@ -1,19 +1,10 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import Auth from './../../stores/Auth';
-import Push from '../../stores/Push'
 import GenericScreenComponent from '../../components/generic/generic_screen'
 
 @observer
 export default class MentionsScreen extends React.Component{
-
-  constructor (props) {
-		super(props)
-  }
-
-  componentDidAppear = async () => {
-    Push.clear_notifications()
-  }
 
   render() {
     return (

--- a/src/screens/settings/settings.js
+++ b/src/screens/settings/settings.js
@@ -4,11 +4,25 @@ import { View, Text, ScrollView, Switch, Platform, ActivityIndicator } from 'rea
 import FastImage from 'react-native-fast-image';
 import App from '../../stores/App'
 import Auth from '../../stores/Auth';
+import Push from '../../stores/Push';
 import Settings from '../../stores/Settings';
 import UserPostingSettings from '../../components/settings/user_posting'
 
 @observer
 export default class SettingsScreen extends React.Component{
+
+	constructor(props) {
+		super(props)
+		this.state = {
+			push_permissions: false
+		}
+	}
+	
+	componentDidMount() {
+		Push.has_push_permissions((has_permissions) => {
+			this.setState({ push_permissions: has_permissions })
+		})
+	}
 	
 	_render_browser_settings = () => {
 		return(
@@ -35,6 +49,12 @@ export default class SettingsScreen extends React.Component{
 		return(
 			<View style={{marginTop: 15}}>
 				<Text style={{ fontWeight: "500", marginBottom: 10, marginTop: 15, marginLeft: 10, color: App.theme_text_color() }}>Push Notifications</Text>
+				{
+					!this.state.push_permissions &&
+					<Text style={{ color: App.theme_error_text_color(), paddingHorizontal: 10, marginBottom: 15, fontWeight: "500" }}>
+						Push notifications are not enabled. Please enable them in your device settings.
+					</Text>
+				}
 				<View style={{ paddingHorizontal: 12, backgroundColor: App.theme_settings_group_background_color(), borderRadius: 8}}>
 					{
 						Auth.users.map((user, index) => {

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -165,6 +165,17 @@ export default App = types.model('App', {
     }
     else if (tab_key.includes("Mentions")) {
       self.current_tab_key = "Mentions"
+      if (Auth.is_logged_in() && Auth.selected_user != null) {
+        Push.has_push_permissions((has_permissions) => {
+          if (has_permissions && !Auth.selected_user.push_registered_with_server) {
+            Auth.selected_user.register_for_push()
+          }
+          else if (!has_permissions) {
+            Push.request_permissions()
+          }
+        })
+        Push.clear_notifications()
+      }
     }
     else if (tab_key.includes("Bookmarks")) {
       self.current_tab_key = "Bookmarks"
@@ -396,10 +407,7 @@ export default App = types.model('App', {
           App.navigate_to_screen("open", number[0])
         }
       }
-      else if(parts?.length >= 2 && parts[0] === "account"){
-        App.open_url(url, true)
-      }
-      else if (parts?.length >= 4) {
+      else if(parts?.length >= 4){
         App.open_url(url)
       }
       else if (parts?.length === 1 && (parts[0] === "summer" || parts[0] === "about")){

--- a/yarn.lock
+++ b/yarn.lock
@@ -3763,6 +3763,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-plugin-transform-remove-console@npm:^6.9.4":
+  version: 6.9.4
+  resolution: "babel-plugin-transform-remove-console@npm:6.9.4"
+  checksum: 10c0/8bb152eed6685b92c371d72be3d9107d879f64b507f3e255edd6a1fb4806e9bcf39011d6f32ce1d8d745fb3533d1da4d5c706eefa633fae25151866c986f2e24
+  languageName: node
+  linkType: hard
+
 "babel-preset-current-node-syntax@npm:^1.0.0":
   version: 1.0.1
   resolution: "babel-preset-current-node-syntax@npm:1.0.1"
@@ -7667,6 +7674,7 @@ __metadata:
     "@xmldom/xmldom": xmldom/xmldom
     axios: "npm:^0.22.0"
     babel-jest: "npm:^29.6.3"
+    babel-plugin-transform-remove-console: "npm:^6.9.4"
     eslint: "npm:^8.19.0"
     fast-xml-parser: "npm:^4.2.2"
     jest: "npm:^29.6.3"


### PR DESCRIPTION
## Push notifications

This tweaks the push notification prompt when the app is first installed.

At the moment it will ask you if you want to enable push notifications at first boot. That's fine, but that causes two issues:

1. The user is thrown this straight away, before login
2. There is an underlying issue where push notifications have been enabled, but after login you never receive them because the token was never registered for the user.

This changes this behaviour by prompting only when the user lands on the Mentions tab, then, once accepted, will push that token to the server for the currently logged in account. This also respects your manual toggle in settings if you want to disable/enable for specific accounts.

I think that's friendlier.

In addition to this, it'll show a message on the settings screen if push notifications are disabled on the system level for the app. Feel free to tweak that wording.

## Production console logs

There is an extra package that will remove all console log statements during the production build. Whilst not an issue, it would be great not to expose anything on the user device that could be logged by accident (although we've been careful).