### PR TITLE
Fix muting & blocking when multiple accounts are available.

### DIFF
--- a/src/screens/settings/muting.js
+++ b/src/screens/settings/muting.js
@@ -30,9 +30,9 @@ export default class MutingScreen extends React.Component {
   }
 
   componentDidMount() {
-    const { selected_user } = Auth
-    if (selected_user?.muting) {
-      selected_user.muting.hydrate()
+    const { user } = this.props.route.params
+    if (user?.muting) {
+      user.muting.hydrate()
     }
   }
 
@@ -56,26 +56,26 @@ export default class MutingScreen extends React.Component {
 
   _handle_add = () => {
     const { new_item, adding_type } = this.state
-    const { selected_user } = Auth
+    const { user } = this.props.route.params
 
     if (!new_item.trim()) {
       return
     }
 
     if (adding_type === "user") {
-      selected_user.muting.mute_user(new_item)
+      user.muting.mute_user(new_item)
     } else if (adding_type === "block") {
-      selected_user.muting.mute_user(new_item, true)
+      user.muting.mute_user(new_item, true)
     } else if (adding_type === "keyword") {
-      selected_user.muting.mute_keyword(new_item)
+      user.muting.mute_keyword(new_item)
     }
 
     this.setState({ new_item: "", adding_type: null })
   }
 
   _handle_unmute = (id, type, name) => {
-    const { selected_user } = Auth
-    const item = selected_user.muting?.muted_items.find(item => item.id === id)
+    const { user } = this.props.route.params
+    const item = user.muting?.muted_items.find(item => item.id === id)
     const is_blocked = item?.is_hiding_other_replies
 
     let title, message
@@ -95,7 +95,7 @@ export default class MutingScreen extends React.Component {
         { 
           text: type === "keyword" ? "Remove" : (is_blocked ? "Unblock" : "Unmute"), 
           style: "destructive",
-          onPress: () => selected_user.muting.unmute_item(id)
+          onPress: () => user.muting.unmute_item(id)
         }
       ]
     )
@@ -103,9 +103,9 @@ export default class MutingScreen extends React.Component {
 
   _render_add_section = (title, type) => {
     const { adding_type, new_item } = this.state
-    const { selected_user } = Auth
+    const { user } = this.props.route.params
     const is_active = adding_type === type
-    const is_loading = selected_user.muting.is_sending_mute || selected_user.muting.is_sending_unmute
+    const is_loading = user.muting.is_sending_mute || user.muting.is_sending_unmute
 
     return (
       <View style={{ marginBottom: 5 }}>
@@ -220,8 +220,8 @@ export default class MutingScreen extends React.Component {
       return null
     }
 
-    const { selected_user } = Auth
-    const is_loading = selected_user.muting.is_sending_unmute
+    const { user } = this.props.route.params
+    const is_loading = user.muting.is_sending_unmute
 
     return (
       <View style={{ 
@@ -284,8 +284,8 @@ export default class MutingScreen extends React.Component {
   }
 
   render() {
-    const { selected_user } = Auth
-    const { muting } = selected_user
+    const { user } = this.props.route.params
+    const { muting } = user
 
     return (
       <KeyboardAvoidingView 

--- a/src/stores/App.js
+++ b/src/stores/App.js
@@ -227,7 +227,7 @@ export default App = types.model('App', {
   }),
   
   navigate_to_screen: flow(function*(screen_name = null, action_data = null, from_listener = false) {
-    console.log("App:navigate_to_screen", screen_name)
+    console.log("App:navigate_to_screen", screen_name, action_data, from_listener)
     if (screen_name != null && self.navigation_ref != null && !self.is_scrolling) {
       switch (screen_name) {
         case "photo":
@@ -291,6 +291,8 @@ export default App = types.model('App', {
           return self.navigation_ref.push(`${self.current_tab_key}-Collections`)
         case "AddCollection":
           return self.navigation_ref.push("AddCollection")
+        case "muting":
+          return self.navigation_ref.push(`muting`, { user: action_data })
         default:
           self.navigation_ref.push(screen_name)
       }

--- a/src/stores/Auth.js
+++ b/src/stores/Auth.js
@@ -88,7 +88,6 @@ export default Auth = types.model('Auth', {
     self.selected_user = user
     if (self.selected_user.posting.selected_service != null) {
       user.posting.selected_service.hydrate()
-      user.fetch_highlights()
       App.close_sheet("main_sheet")
     }
     self.is_selecting_user = false

--- a/src/stores/models/User.js
+++ b/src/stores/models/User.js
@@ -5,7 +5,7 @@ import FastImage from 'react-native-fast-image';
 import Muting from './Muting'
 import Push from '../Push'
 import App from '../App'
-import MicroBlogApi, { API_ERROR, DELETE_ERROR, LOGIN_TOKEN_INVALID } from '../../api/MicroBlogApi';
+import MicroBlogApi, { API_ERROR, LOGIN_TOKEN_INVALID } from '../../api/MicroBlogApi';
 
 export default User = types.model('User', {
     username: types.identifier,


### PR DESCRIPTION
Hey @manton,

This fixes the issue when the wrong muting list was presented to the user when multiple accounts are used in the app. This now correctly uses the route parameters, which passes through the user object.

Because I looked at it for too long, I used the currently selected user when loading the screen — my mistake 😵‍💫

This also fixes an issue with trying to load highlights when switching accounts — which no longer is used.