### PR TITLE
Fix back button hit area. Add new category and summary input for posts. Fix upload destination bug. Fix muted list when switching accounts.

### DIFF
--- a/src/api/MicroPubApi.js
+++ b/src/api/MicroPubApi.js
@@ -321,7 +321,7 @@ class MicroPubApi {
 			type: file.type,
 			uri: file.uri,
 		})
-		data.append("mp-destination", destination)
+		data.append("mp-destination", App.current_screen_name === "microblog.UploadsScreen" || service.temporary_destination !== null && service.temporary_destination !== service.destination ? service.temporary_destination : service.destination)
 		console.log('MicroPubApi:upload_media', service, file, data)
 
 		const upload = axios

--- a/src/api/MicroPubApi.js
+++ b/src/api/MicroPubApi.js
@@ -154,7 +154,7 @@ class MicroPubApi {
 		return config;
 	}
 
-	async send_post(service, content, title = null, assets = [], categories = [], status = null, syndicate_to = null) {
+	async send_post(service, content, title = null, assets = [], categories = [], status = null, syndicate_to = null, summary = null) {
 		console.log('MicroBlogApi:send_post', service, content, title, assets, status, syndicate_to);		
 		const params = new FormData()
 		params.append('h', 'entry')
@@ -212,6 +212,9 @@ class MicroPubApi {
 		}
 		else if(syndicate_to != null && syndicate_to.length === 0){
 			params.append('mp-syndicate-to[]', "")
+		}
+		if (summary) {
+			params.append('summary', summary)
 		}
 		console.log("MicroBlogApi:send_post:FORM_DATA:PARAMS", params)
 		const post = axios

--- a/src/components/header/back.js
+++ b/src/components/header/back.js
@@ -17,6 +17,14 @@ const BackButtonContent = observer(() => {
           navigation.goBack()
         }
       }}
+      style={{
+        marginLeft: -20,
+        paddingHorizontal: 20,
+        paddingBottom: 10,
+        marginBottom: -10,
+        paddingTop: 10,
+        marginTop: -10
+      }}
       labelVisible={false}
       backImage={() => (
         Platform.OS === 'ios' ?

--- a/src/screens/posts/options.js
+++ b/src/screens/posts/options.js
@@ -149,6 +149,7 @@ export default class PostingOptionsScreen extends React.Component{
 							value={posting.summary}
 							onChangeText={posting.set_summary}
 							clearButtonMode="always"
+							multiline
 						/>
 					</View>
 				)}

--- a/src/screens/posts/options.js
+++ b/src/screens/posts/options.js
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
-import { View, Text, TouchableOpacity, ScrollView } from 'react-native';
+import { View, Text, TouchableOpacity, ScrollView, TextInput, KeyboardAvoidingView, Platform } from 'react-native';
 import Auth from '../../stores/Auth';
 import App from '../../stores/App'
 import CheckmarkRowCell from '../../components/cells/checkmark_row_cell'
 
 @observer
 export default class PostingOptionsScreen extends React.Component{
-
 	componentDidMount() {
     if (Auth.selected_user.posting.selected_service != null) {
       Auth.selected_user.posting.selected_service.check_for_categories()
@@ -17,7 +16,12 @@ export default class PostingOptionsScreen extends React.Component{
   render() {
     const { posting } = Auth.selected_user
     return(
-			<ScrollView style={{ flex: 1, padding: 15 }}>
+      <KeyboardAvoidingView 
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={{ flex: 1 }}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 125 : 0}
+      >
+			  <ScrollView style={{ flex: 1, padding: 15 }}>
 				{/* Post status */}
 				{
 				  !posting.is_editing_post &&
@@ -74,6 +78,34 @@ export default class PostingOptionsScreen extends React.Component{
 							})
 						: <Text style={{ color: App.theme_button_text_color() }}>No categories to display</Text>
 					}
+						<View style={{ 
+							flexDirection: 'row', 
+							alignItems: 'center',
+              marginTop: 8
+						}}>
+							<TextInput
+								style={{
+									flex: 1,
+									color: App.theme_button_text_color(),
+									padding: 8,
+									paddingHorizontal: 12,
+									fontSize: 16,
+									backgroundColor: App.theme_input_background_color(),
+									borderRadius: 6,
+									marginRight: 4,
+									borderWidth: 1,
+									borderColor: App.theme_border_color()
+								}}
+								placeholder="Add new category..."
+								placeholderTextColor={App.theme_placeholder_text_color()}
+								value={posting.new_category_text}
+								onChangeText={(text) => posting.handle_new_category_text(text)}
+								clearButtonMode="always"
+							/>
+							{posting.new_category_text && (
+								<CheckmarkRowCell text="" is_selected={posting.post_categories.includes(posting.new_category_text)} />
+							)}
+						</View>
 					</View>
 				</View>
 				{/* Cross posting */}
@@ -141,6 +173,7 @@ export default class PostingOptionsScreen extends React.Component{
 					</TouchableOpacity>
 				</View>
       </ScrollView>
+    </KeyboardAvoidingView>
     )
   }
   

--- a/src/screens/posts/options.js
+++ b/src/screens/posts/options.js
@@ -21,7 +21,10 @@ export default class PostingOptionsScreen extends React.Component{
         style={{ flex: 1 }}
         keyboardVerticalOffset={Platform.OS === "ios" ? 125 : 0}
       >
-			  <ScrollView style={{ flex: 1, padding: 15 }}>
+			  <ScrollView 
+          style={{ flex: 1 }}
+          contentContainerStyle={{ padding: 15, paddingBottom: 50 }}
+          showsVerticalScrollIndicator={true}>
 				{/* Post status */}
 				{
 				  !posting.is_editing_post &&
@@ -108,6 +111,47 @@ export default class PostingOptionsScreen extends React.Component{
 						</View>
 					</View>
 				</View>
+				{/* Other options */}
+				<View style={{ marginBottom: 25 }}>
+					<Text style={{ fontSize: 16, fontWeight: '500', color: App.theme_text_color() }}>View:</Text>
+					<View style={{ backgroundColor: App.theme_button_background_color(), padding: 8, borderRadius: 8, marginTop: 8 }}>
+						<TouchableOpacity
+							style={{
+								padding: 8,
+								marginVertical: 2.5,
+								flexDirection: 'row',
+								alignItems: 'center',
+							}}
+							onPress={posting.toggle_title}
+						>
+							<CheckmarkRowCell text="Show title field" is_selected={posting.show_title} />
+						</TouchableOpacity>
+					</View>
+				</View>
+				{/* Summary */}
+				{posting.selected_service.type !== "xmlrpc" && (
+					<View style={{ marginBottom: 25 }}>
+						<Text style={{ fontSize: 16, fontWeight: '500', color: App.theme_text_color(), marginBottom: 8 }}>Summary:</Text>
+						<TextInput
+							style={{
+								color: App.theme_button_text_color(),
+								padding: 8,
+								paddingHorizontal: 12,
+								fontSize: 16,
+								backgroundColor: App.theme_input_background_color(),
+								borderRadius: 6,
+								marginRight: 4,
+								borderWidth: 1,
+								borderColor: App.theme_border_color()
+							}}
+							placeholder="Summary"
+							placeholderTextColor={App.theme_placeholder_text_color()}
+							value={posting.summary}
+							onChangeText={posting.set_summary}
+							clearButtonMode="always"
+						/>
+					</View>
+				)}
 				{/* Cross posting */}
 				{
 				  !posting.is_editing_post &&
@@ -140,23 +184,7 @@ export default class PostingOptionsScreen extends React.Component{
 						</View>
 					</View>
 				}
-				{/* Other options */}
-				<View style={{ marginBottom: 25 }}>
-					<Text style={{ fontSize: 16, fontWeight: '500', color: App.theme_text_color() }}>View:</Text>
-					<View style={{ backgroundColor: App.theme_button_background_color(), padding: 8, borderRadius: 8, marginTop: 8 }}>
-						<TouchableOpacity
-							style={{
-								padding: 8,
-								marginVertical: 2.5,
-								flexDirection: 'row',
-								alignItems: 'center',
-							}}
-							onPress={posting.toggle_title}
-						>
-							<CheckmarkRowCell text="Show title field" is_selected={posting.show_title} />
-						</TouchableOpacity>
-					</View>
-				</View>
+				{/* Markdown reference */}
 				<View style={{ alignItems: 'center' }}>
 					<TouchableOpacity
 						style={{

--- a/src/stores/models/Muting.js
+++ b/src/stores/models/Muting.js
@@ -25,6 +25,7 @@ export default Muting = types.model('Muting', {
 
 	hydrate: flow(function* () {
 		console.log("Muting:hydrate")
+		self.muted_items = [];
 		const muted_items = yield MicroBlogApi.get_muted_users(self.token());
 		if (muted_items && muted_items !== API_ERROR) {
 			self.muted_items = muted_items;

--- a/src/stores/models/Posting.js
+++ b/src/stores/models/Posting.js
@@ -21,6 +21,7 @@ export default Posting = types.model('Posting', {
   is_sending_post: types.optional(types.boolean, false),
   post_assets: types.optional(types.array(MediaAsset), []),
   post_categories: types.optional(types.array(types.string), []),
+  new_category_text: types.optional(types.string, ""),
   post_syndicates: types.optional(types.array(types.string), []),
   post_status: types.optional(types.string, "published"),
   is_adding_bookmark: types.optional(types.boolean, false),
@@ -173,6 +174,7 @@ export default Posting = types.model('Posting', {
       self.post_title = null
       self.post_assets = []
       self.post_categories = []
+      self.new_category_text = ""
       self.post_status = "published"
       if(self.selected_service && self.selected_service.active_destination()?.syndicates?.length > 0){
         let syndicate_targets = []
@@ -414,6 +416,7 @@ export default Posting = types.model('Posting', {
     self.post_title = null
     self.post_assets = []
     self.post_categories = []
+    self.new_category_text = ""
     self.is_editing_post = false
     self.post_url = null
     self.show_title = false
@@ -518,6 +521,21 @@ export default Posting = types.model('Posting', {
   
   add_to_post_text: flow(function* (text) {
     self.post_text += text
+  }),
+  
+  handle_new_category_text: flow(function* (text) {
+    if (self.new_category_text) {
+      self.post_categories = self.post_categories.filter(c => !self.new_category_text.startsWith(c) && !c.startsWith(self.new_category_text))
+    }
+    
+    self.new_category_text = text
+    
+    if (text) {
+      self.post_categories = self.post_categories.filter(c => !text.startsWith(c) && !c.startsWith(text))
+      if (!self.post_categories.includes(text)) {
+        self.post_categories.push(text)
+      }
+    }
   }),
   
 }))

--- a/src/stores/models/posting/Destination.js
+++ b/src/stores/models/posting/Destination.js
@@ -46,6 +46,7 @@ export default Destination = types.model('Destination', {
 			const url = entry.properties.url ? entry.properties.url[0] : ""
 			const post_status = entry.properties["post-status"] ? entry.properties["post-status"][0] : ""
 			const categories = entry.properties.category ? entry.properties.category : []
+			const summary = entry.properties.summary ? entry.properties.summary[0] : null
 			const post = {
 				uid: uid,
 				name: name,
@@ -53,7 +54,8 @@ export default Destination = types.model('Destination', {
 				published: published,
 				url: url,
 				post_status: post_status,
-				category: categories
+				category: categories,
+				summary: summary
 			}
 			if (uid === 0 || url === "") {
 				return acc

--- a/src/stores/models/posting/Post.js
+++ b/src/stores/models/posting/Post.js
@@ -12,7 +12,8 @@ export default Post = types.model('Post', {
   published: types.maybe(types.string),
   url: types.maybe(types.string),
   post_status: types.maybe(types.string),
-  category: types.optional(types.array(types.string), [])
+  category: types.optional(types.array(types.string), []),
+  summary: types.maybeNull(types.string)
 })
 .views(self => ({
   


### PR DESCRIPTION
This change adds a fix for the hit area around the back button so it is easier to tap.

Also in this change I added the ability to add a new category to a post — I kept it simple and you can add one in the input field, deleting it will ignore it. There is also a visual tick that shows up so it's clearer that it will be sent across.

After the post is sent, that new category is automatically fetched and the input field is cleared.

![Simple input field](https://github.com/user-attachments/assets/b35978eb-0042-4ab1-9b6a-e11c62cc62cf)

https://github.com/user-attachments/assets/257fe98d-4a55-4e82-9e32-51b3cc1c8374

