### PR TITLE
Alt text tweaks, uploads CDN

### DIFF
--- a/src/components/cells/upload_cell.js
+++ b/src/components/cells/upload_cell.js
@@ -81,6 +81,11 @@ export default class UploadCell extends React.Component {
 			)
 		}
 		else {
+			let best_url = upload.url;
+			if (upload.cdn && upload.cdn.small) {
+				best_url = upload.cdn.small;
+			}
+			
 			return (
 				<FastImage
 					key={upload.url}

--- a/src/screens/posts/image_options.js
+++ b/src/screens/posts/image_options.js
@@ -42,21 +42,39 @@ export default class ImageOptionsScreen extends React.Component{
   _check_uploads_for_text(results) {
     const { asset } = this.props.route.params;
     let found = false;
-    
+  
     if (results.items != null) {
       for (let item of results.items) {
-        if (item.url == asset.remote_url) {
-          if (item.alt.length > 0) {
-            found = true;
-            this.setState({ isLoadingAlt: false, generatedAltText: item.alt });
+        if (item.url === asset.remote_url && item.alt.length > 0) {
+          found = true;
+  
+          // if user hasn't typed any alt_text yet, fill it in and hide the robot bar
+          if (!asset.alt_text || asset.alt_text.trim().length === 0) {
+            // wait a half second just to give visual clue that this was auto-generated
+            setTimeout(() => {
+              asset.set_alt_text(item.alt);
+              this.setState({
+                isLoadingAlt: false,
+                generatedAltText: ""
+              });
+            }, 500);
           }
+          else {
+            // user has already typed something, so show the bar
+            this.setState({
+              isLoadingAlt: false,
+              generatedAltText: item.alt
+            });
+          }
+  
+          break;
         }
       }
     }
-    
+  
     return found;
   }
-
+  
   render() {
     const { posting } = Auth.selected_user
     const { asset } = this.props.route.params
@@ -120,7 +138,16 @@ export default class ImageOptionsScreen extends React.Component{
             />
           </View>
           { (this.state.isLoadingAlt || (this.state.generatedAltText.length > 0)) && 
-            <View style={{ flexDirection: "row", minHeight: 40, alignItems: "center", width: "100%", padding: 8 }}>
+            <View style={{
+              flexDirection: "row",
+              minHeight: 40,
+              alignItems: "center",
+              width: "100%",
+              padding: 8,
+              paddingVertical: 10,
+              borderBottomWidth: 1,
+              borderBottomColor: App.theme_section_background_color()
+            }}>
               { this.state.isLoadingAlt ? 
                 <>
                   <Text numberOfLines={1} style={{ color: App.theme_text_color() }}>🤖</Text>
@@ -170,7 +197,7 @@ export default class ImageOptionsScreen extends React.Component{
               scrollEnabled={false}
               returnKeyType={'default'}
               keyboardType={'default'}
-              autoFocus={false}
+              autoFocus={true}
               autoCorrect={true}
               clearButtonMode={'while-editing'}
               enablesReturnKeyAutomatically={true}

--- a/src/stores/models/posting/Destination.js
+++ b/src/stores/models/posting/Destination.js
@@ -131,13 +131,15 @@ export default Destination = types.model('Destination', {
 			const published = entry.published || ""
 			const poster = entry.poster || ""
 			const alt = entry.alt || ""
-			let is_ai = entry["microblog-ai"]
+			const is_ai = entry["microblog-ai"]
+			const cdn = entry.cdn || {}
 			const upload = {
 				url: url,
 				published: published,
 				poster: poster,
 				alt: alt,
-				is_ai: is_ai
+				is_ai: is_ai,
+				cdn: cdn
 			}
 			if (url === "") {
 				return acc;

--- a/src/stores/models/posting/Upload.js
+++ b/src/stores/models/posting/Upload.js
@@ -7,7 +7,8 @@ export default Upload = types.model('Upload', {
 	published: types.maybe(types.string),
 	poster: types.maybe(types.string),
 	alt: types.maybe(types.string),
-	is_ai: types.optional(types.boolean, true)
+	is_ai: types.optional(types.boolean, true),
+	cdn: types.optional(types.map(types.string), {})
 })
 	.actions(self => ({
 


### PR DESCRIPTION
Changed the image options pane to be more similar to the new dialog on the Mac, where if we find AI-generated alt text, we include it in the text field right away instead of making the user copy/paste it. Also switch to loading the image thumbnails from the CDN.